### PR TITLE
Display string of a person attribute of type concept 

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import org.openmrs.Concept;
 import org.openmrs.Person;
 import org.openmrs.PersonAttribute;
 import org.openmrs.api.context.Context;
@@ -172,7 +173,10 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 	public String getDisplayString(PersonAttribute pa) {
 		if (pa.getAttributeType() == null)
 			return "";
-		
+	if (Concept.class.getName().equals(pa.getAttributeType().getFormat()) && pa.getValue() != null) {
+		Concept concept = Context.getConceptService().getConcept(pa.getValue());
+		return concept == null ? null : concept.getDisplayString();
+	}
 		return pa.getAttributeType().getName() + " = " + pa.getValue();
 	}
 


### PR DESCRIPTION
Currently the person attributes of type concept in the get patient API returns id of the concept. For a external system which needs to read patient data, it has to multiple more web requests to get meaningful value for the attributes of type concept.

The current implementation is one of the way to achieve this, with a slight hit on the performance. If there other alternative ways to get the concept data without having to make multiple calls, please feel free to suggest.

Example: 

```
           {
                "display": "Student", // Instead of "occupation - 24"
                "value": "24",
                "attributeType": {
                    "display": "occupation",
                },
            }
```
