### PR TITLE
SubclassHandlers now have versions.

### DIFF
--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10.java
@@ -13,18 +13,16 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 
-import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.CareSetting;
 import org.openmrs.DrugOrder;
 import org.openmrs.Order;
 import org.openmrs.Patient;
-import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
@@ -35,11 +33,13 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.DrugOrderSubclassHandler1_8;
 
+import java.util.List;
+
 /**
  * Exposes the {@link org.openmrs.DrugOrder} subclass as a type in
  * {@link org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10.DrugOrderSubclassHandler1_10}
  */
-@Handler(supports = DrugOrder.class)
+@SubClassHandler(supportedClass = DrugOrder.class, supportedOpenmrsVersions = {"1.10.*"})
 public class DrugOrderSubclassHandler1_10 extends DrugOrderSubclassHandler1_8 {
 	
 	/**

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
@@ -13,18 +13,16 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 
-import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.CareSetting;
 import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.TestOrder;
-import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
@@ -36,11 +34,13 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubclassH
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 
+import java.util.List;
+
 /**
  * Exposes the {@link org.openmrs.TestOrder} subclass as a type in
  * {@link org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.OrderResource1_8}
  */
-@Handler(supports = TestOrder.class)
+@SubClassHandler(supportedClass = TestOrder.class, supportedOpenmrsVersions = "1.10.*")
 public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<Order, TestOrder> implements DelegatingSubclassHandler<Order, TestOrder> {
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
@@ -22,6 +22,7 @@ import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
@@ -37,7 +38,7 @@ import org.openmrs.util.OpenmrsConstants;
 /**
  * Exposes the {@link DrugOrder} subclass as a type in {@link OrderResource1_8}
  */
-@Handler(supports = DrugOrder.class)
+@SubClassHandler(supportedClass = DrugOrder.class, supportedOpenmrsVersions = {"1.8.*", "1.9.*"})
 public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<Order, DrugOrder> implements DelegatingSubclassHandler<Order, DrugOrder> {
 	
 	/**

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/HivDrugOrderSubclassHandler.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/HivDrugOrderSubclassHandler.java
@@ -17,6 +17,7 @@ import org.openmrs.Order;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
+import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -30,6 +31,7 @@ import org.openmrs.util.OpenmrsConstants;
 /**
  * This is a contrived example for testing purposes
  */
+@SubClassHandler(supportedClass = HivDrugOrder.class, supportedOpenmrsVersions = {"1.8.*"})
 public class HivDrugOrderSubclassHandler extends BaseDelegatingSubclassHandler<Order, HivDrugOrder> implements DelegatingSubclassHandler<Order, HivDrugOrder> {
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/annotation/SubClassHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/annotation/SubClassHandler.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.webservices.rest.web.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Holds metadata that represents a subclass handler.
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SubClassHandler {
+	
+	Class<?> supportedClass();
+	
+	String[] supportedOpenmrsVersions();
+}

--- a/omod-common/src/main/resources/webModuleApplicationContext.xml
+++ b/omod-common/src/main/resources/webModuleApplicationContext.xml
@@ -111,7 +111,9 @@
 	<mvc:annotation-driven />
 	-->
 	
-	<context:component-scan base-package="org.openmrs.module.webservices.rest.web"/>
+	<context:component-scan base-package="org.openmrs.module.webservices.rest.web">
+        <context:include-filter type="annotation" expression="org.openmrs.module.webservices.rest.web.annotation.SubClassHandler"/>
+    </context:component-scan>
     
     <!-- Must be placed after DefaultAnnotationHandlerMapping to handle unknown resource requests which result in 404.  -->
     <bean class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">


### PR DESCRIPTION
Currently, there is no way of writing different SubClassHandlers for different versions of OpenMRS. This commit aims to fix it.
The new SubClassHandler annotation will ensure the right version is taken. We do a few things to ensure modules that have defined SubClassHandlers of their own do not fail.
1. If the annotation is not specified, the SubClassHandler will still be loaded for the resource.
2. We ensure that any SubClassHandler will be picked up from the Context. This also allows clients to use Spring for DI for their own SubClassHandlers.

Thanks
Neha/Vinay
