### PR TITLE
RESTWS-454: Added the missing deathDate property to updatable properties

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
@@ -133,6 +133,7 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
         description.addRequiredProperty("names");
         description.addRequiredProperty("causeOfDeath");
         description.addRequiredProperty("dead");
+        description.addProperty("deathDate");
         return description;
     }
 	


### PR DESCRIPTION
It appears "deathDate" was mistakenly forgotten as @djazayeri  pointed out in the corresponding mailing list thread.
