### PR TITLE
RESTWS-511 | Allow voided property in update to support voiding relat…

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
@@ -141,6 +141,7 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
         //shouldn't be editing the patient
         description.removeProperty("personA");
         description.removeProperty("personB");
+        description.addProperty("voided");
         return description;
     }
 }


### PR DESCRIPTION
Missed the voided property in one of the reverts and new commits - https://github.com/openmrs/openmrs-module-webservices.rest/commit/31431ef24d864bde7632114de1a95e3077935b4c. We need this as specified in the feature request for "Update of relationship should also take 'voided' to allow delete of relationship."