### PR TITLE
RESTWS-529: Fixed incorrect behaviour when submitting uuid for coded …

### DIFF
--- a/omod-1.8/pom.xml
+++ b/omod-1.8/pom.xml
@@ -11,7 +11,7 @@
 	<description>OpenMRS module project for Rest Web Services</description>
 
 	<properties>
-		<openmrs.version.1.8>1.8.1</openmrs.version.1.8>
+		<openmrs.version.1.8>1.8.4</openmrs.version.1.8>
 	</properties>
 
 	<dependencies>

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -322,13 +322,18 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> {
 						}
 					}
 				} else if (obs.getConcept().getDatatype().isBoolean()) {
-					if (value.equals(Context.getConceptService().getTrueConcept())) {
-						value = true;
-					} else if (value.equals(Context.getConceptService().getFalseConcept())) {
-						value = false;
-					} else if (!value.getClass().isAssignableFrom(Boolean.class)) {
-						throw new APIException("Unexpected value: " + value + " set as the value of boolean. Boolean, ConceptService.getTrueConcept or , ConceptService.getFalseConcept expected");
-					}
+                    if (value instanceof Concept) {
+                        value = ((Concept)value).getUuid();
+                    }
+                    if(value.equals(Context.getConceptService().getTrueConcept().getUuid())) {
+                        value = true;
+                    } else if(value.equals(Context.getConceptService().getFalseConcept().getUuid())) {
+                        value = false;
+                    } else if(!value.getClass().isAssignableFrom(Boolean.class)) {
+                        throw new ConversionException("Unexpected value: " + value +
+                                " set as the value of boolean. Boolean, ConceptService.getTrueConcept or " +
+                                ", ConceptService.getFalseConcept expected");
+                    }
 				}
 				obs.setValueAsString(value.toString());
 			}

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/HL7MessageController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/HL7MessageController1_8Test.java
@@ -31,7 +31,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
  */
 public class HL7MessageController1_8Test extends MainResourceControllerTest {
 	
-	private static final String hl7Data = "MSH|^~\\&|NES|AMRS.ELD|TESTSYSTEM|TESTFACILITY|20010101000000||ADT^A04|REl7wt78q9Pzlqe9ecJB|P|2.3";
+	private static final String hl7Data = "MSH|^~\\&|NES|AMRS.ELD|TESTSYSTEM|TESTFACILITY|20010101000000||ADT^A04|REl7wt78q9Pzlqe9ecJB|P|2.5";
 	
 	private static final String hl7InvalidSourceData = "MSH|^~\\&|NES|nonexistingsource|TESTSYSTEM|TESTFACILITY|20010101000000||ADT^A04|REl7wt78q9Pzlqe9ecJB|P|2.3";
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8Test.java
@@ -28,6 +28,7 @@ import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
+import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.util.OpenmrsConstants;
 
 import java.util.Date;
@@ -232,7 +233,7 @@ public class ObsResource1_8Test extends BaseDelegatingResourceTest<ObsResource1_
 		assertEquals(falseConcept, ObsResource1_8.getValue(obs));
 	}
 
-	@Test(expected = APIException.class)
+	@Test(expected = ConversionException.class)
 	public void setValue_shouldThrowExceptionOnUnexpectedValue() throws Exception {
 		Obs obs = new Obs();
 		obs.setConcept(Context.getConceptService().getConceptByUuid(BOOLEAN_CONCEPT_UUID));

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsController1_9Test.java
@@ -16,9 +16,13 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_9;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.openmrs.util.OpenmrsConstants;
 
 /**
  * Created by tomasz on 27.04.15.
@@ -47,7 +51,7 @@ public class ObsController1_9Test extends MainResourceControllerTest {
 
     @Override
     public long getAllCount() {
-        return 0; //Not supported
+        return Context.getObsService().getObservationCount(null,true);
     }
 
     /**
@@ -65,6 +69,40 @@ public class ObsController1_9Test extends MainResourceControllerTest {
     @Test(expected = ResourceDoesNotSupportOperationException.class)
     public void shouldGetAll() throws Exception {
         super.shouldGetAll();
+    }
+
+    @Test
+    public void shouldSubmitProperValueCodedWhenBooleanConceptUuidIsPassedAsValue() throws Exception {
+        final String yesConceptUuid = "b055abd8-a420-4a11-8b98-02ee170a7b54";
+        final String yesConceptId = "7";
+        final String noConceptUuid = "934d8ef1-ea43-4f98-906e-dd03d5faaeb4";
+        final String noConceptId = "8";
+
+        AdministrationService as = Context.getAdministrationService();
+
+        as.saveGlobalProperty(new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_TRUE_CONCEPT, yesConceptId));
+        as.saveGlobalProperty(new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_FALSE_CONCEPT, noConceptId));
+
+        long before = getAllCount();
+
+        String yesPayload = "{\"concept\":\"0dde1358-7fcf-4341-a330-f119241a46e8\"," +
+                "\"value\":\"" + yesConceptUuid + "\",\"person\":\"5946f880-b197-400b-9caa-a3c661d23041\"," +
+                "\"obsDatetime\":\"2015-09-07T00:00:00.000+0530\"}";
+
+        String noPayload = "{\"concept\":\"0dde1358-7fcf-4341-a330-f119241a46e8\"," +
+                "\"value\":\"" + noConceptUuid + "\",\"person\":\"5946f880-b197-400b-9caa-a3c661d23041\"," +
+                "\"obsDatetime\":\"2015-09-07T00:00:00.000+0530\"}";
+
+
+        Object yesCreated = deserialize(handle(newPostRequest(getURI(), yesPayload)));
+        Object yesValue = PropertyUtils.getProperty(yesCreated, "value");
+
+        Object noCreated = deserialize(handle(newPostRequest(getURI(), noPayload)));
+        Object noValue =  PropertyUtils.getProperty(noCreated, "value");
+
+        Assert.assertEquals(before + 2, getAllCount());
+        Assert.assertEquals(yesConceptUuid, PropertyUtils.getProperty(yesValue, "uuid"));
+        Assert.assertEquals(noConceptUuid, PropertyUtils.getProperty(noValue, "uuid"));
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openmrs.version>1.8.1</openmrs.version>
+		<openmrs.version>1.8.4</openmrs.version>
 
 		<MODULE_ID>${project.parent.artifactId}</MODULE_ID>
 		<MODULE_NAME>${project.parent.name}</MODULE_NAME>


### PR DESCRIPTION
This is a fix to the way the Property setter for value handles coded boolean values. Initially the passed was being compared to the Concept object for true/false (i.e Yes/No). That implementation caused the comparison to always return false. This fix makes the comparison against the concept uuid instead which is the expected behaviour.