### PR TITLE
RESTWS-459: Added unit test

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
@@ -79,6 +79,9 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 	@PropertySetter("identifiers")
 	public static void setIdentifiers(Patient instance, List<PatientIdentifier> identifiers)
 	        throws ResourceDoesNotSupportOperationException {
+		if (instance.getIdentifiers() != null && instance.getIdentifiers().containsAll(identifiers)) {
+			return;
+		}
 		if (instance.getIdentifiers() != null && !instance.getIdentifiers().isEmpty()) {
 			throw new ResourceDoesNotSupportOperationException("Identifiers can only be set for newly created objects!");
 		}

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/EncounterController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/EncounterController1_8Test.java
@@ -74,6 +74,17 @@ public class EncounterController1_8Test extends MainResourceControllerTest {
 		Assert.assertNotNull(newEncounter);
 		Assert.assertEquals(before + 1, Context.getEncounterService().getAllEncounters(null).size());
 	}
+	
+	@Test
+	public void createEncounter_shouldCreateANewEncounterUsingPatientRef() throws Exception {
+		int countBefore = Context.getEncounterService().getAllEncounters(null).size();
+		String json = "{\"location\":\"9356400c-a5a2-4532-8f2b-2361b3446eb8\", \"encounterType\": \"61ae96f4-6afe-4351-b6f8-cd4fc383cce1\", \"encounterDatetime\": \"2011-01-15\", \"patient\": { \"uuid\" : \"da7f524f-27ce-4bb2-86d6-6d1d05312bd5\", \"identifiers\": [\"8a9aac6e-3f9f-4ed2-8fb5-25215f8bb614\"], \"person\": \"da7f524f-27ce-4bb2-86d6-6d1d05312bd5\" }, \"provider\":\"ba1b19c2-3ed6-4f63-b8c0-f762dc8d7562\"}";
+		
+		Object newEncounter = deserialize(handle(newPostRequest(getURI(), json)));
+		
+		Assert.assertNotNull(newEncounter);
+		Assert.assertEquals(countBefore + 1, Context.getEncounterService().getAllEncounters(null).size());
+	}
 
     @Test
     public void createEncounter_shouldDefaultDatetimeToNowIfNotSpecified() throws Exception {


### PR DESCRIPTION
Added unit test to confirm that fix for https://issues.openmrs.org/browse/RESTWS-460, also allows submitting encounters with patient properties other than the uuid.