### PR TITLE
RESTWS-536: refactoring of getAuditInfo

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
@@ -19,8 +19,6 @@ import java.util.List;
 import org.openmrs.Concept;
 import org.openmrs.ConceptDescription;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -170,23 +168,6 @@ public class ConceptDescriptionResource1_8 extends DelegatingSubResource<Concept
 	@PropertyGetter("display")
 	public String getDisplayString(ConceptDescription conceptDescription) {
 		return conceptDescription.getDescription();
-	}
-	
-	/**
-	 * Gets extra book-keeping info, for the full representation
-	 * 
-	 * @param description
-	 * @return
-	 * @throws Exception
-	 */
-	public SimpleObject getAuditInfo(ConceptDescription description) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(description, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(description.getDateCreated(), Representation.DEFAULT));
-		ret.put("changedBy", ConversionUtil.getPropertyWithRepresentation(description, "changedBy", Representation.REF));
-		ret.put("dateChanged", ConversionUtil.convertToRepresentation(description.getDateChanged(), Representation.DEFAULT));
-		
-		return ret;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -52,7 +52,6 @@ import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
 import org.openmrs.module.webservices.rest.web.resource.impl.AlreadyPaged;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
-import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
@@ -294,28 +293,6 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 	public String getDisplayName(Concept instance) {
 		ConceptName cn = instance.getName();
 		return cn == null ? null : cn.getName();
-	}
-	
-	/**
-	 * Must put this here because we cannot extend {@link MetadataDelegatingCrudResource}
-	 * 
-	 * @param concept the delegate concept
-	 * @return audit information
-	 * @throws Exception
-	 */
-	public SimpleObject getAuditInfo(Concept concept) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(concept, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(concept.getDateCreated(), Representation.DEFAULT));
-		if (concept.isRetired()) {
-			ret.put("retiredBy", ConversionUtil.getPropertyWithRepresentation(concept, "retiredBy", Representation.REF));
-			ret.put("dateRetired", ConversionUtil.convertToRepresentation(concept.getDateRetired(), Representation.DEFAULT));
-			ret.put("retireReason", ConversionUtil
-			        .convertToRepresentation(concept.getRetireReason(), Representation.DEFAULT));
-		}
-		ret.put("changedBy", ConversionUtil.getPropertyWithRepresentation(concept, "changedBy", Representation.REF));
-		ret.put("dateChanged", ConversionUtil.convertToRepresentation(concept.getDateChanged(), Representation.DEFAULT));
-		return ret;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
@@ -20,7 +20,6 @@ import org.openmrs.Field;
 import org.openmrs.FieldAnswer;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -128,20 +127,6 @@ public class FieldAnswerResource1_8 extends DelegatingSubResource<FieldAnswer, F
 	@Override
 	protected void delete(FieldAnswer delegate, String reason, RequestContext context) throws ResponseException {
 		throw new UnsupportedOperationException("A field answer must be removed from a field, not deleted on its own.");
-	}
-	
-	/**
-	 * provide audit info for a FieldAnswer
-	 * 
-	 * @param delegate
-	 * @return the auditInfo
-	 * @throws Exception
-	 */
-	public SimpleObject getAuditInfo(FieldAnswer delegate) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(delegate, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(delegate.getDateCreated(), Representation.DEFAULT));
-		return ret;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
@@ -13,14 +13,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
-import org.openmrs.Auditable;
-import org.openmrs.BaseOpenmrsObject;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.Form;
 import org.openmrs.FormField;
-import org.openmrs.Retireable;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -33,9 +31,6 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * {@link Resource} for {@link FormField}, supporting standard CRUD operations
@@ -107,25 +102,6 @@ public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form,
 		description.addProperty("sortWeight");
 		
 		return description;
-	}
-	
-	/**
-	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResource#getAuditInfo(org.openmrs.BaseOpenmrsObject)
-	 */
-	@Override
-	public SimpleObject getAuditInfo(BaseOpenmrsObject resource) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(resource, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(((Auditable) resource).getDateCreated(),
-		    Representation.DEFAULT));
-		if (((Retireable) resource).isRetired()) {
-			ret.put("retiredBy", ConversionUtil.getPropertyWithRepresentation(resource, "retiredBy", Representation.REF));
-			ret.put("dateRetired", ConversionUtil.convertToRepresentation(((Retireable) resource).getDateRetired(),
-			    Representation.DEFAULT));
-			ret.put("retireReason", ConversionUtil.convertToRepresentation(((Retireable) resource).getRetireReason(),
-			    Representation.DEFAULT));
-		}
-		return ret;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
@@ -13,6 +13,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
 import org.openmrs.Person;
 import org.openmrs.PersonAddress;
 import org.openmrs.PersonAttribute;
@@ -35,11 +40,6 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.util.OpenmrsUtil;
-
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
 
 /**
  * {@link Resource} for Person, supporting standard CRUD operations
@@ -88,7 +88,7 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 			description.addProperty("addresses");
 			description.addProperty("attributes", "activeAttributes", Representation.DEFAULT);
 			description.addProperty("voided");
-			description.addProperty("auditInfo", findMethod("getAuditInfo"));
+			description.addProperty("auditInfo");
 			description.addSelfLink();
 			return description;
 		}
@@ -471,18 +471,10 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
      * @return audit information
      * @throws Exception
      */
-    @Override
+    @PropertyGetter("auditInfo")
     public SimpleObject getAuditInfo(Person person) throws Exception {
-        SimpleObject ret = new SimpleObject();
-        ret.put("creator", ConversionUtil.getPropertyWithRepresentation(person, "creator", Representation.REF));
+        SimpleObject ret = super.getAuditInfo(person);
         ret.put("dateCreated", ConversionUtil.convertToRepresentation(person.getPersonDateCreated(), Representation.DEFAULT));
-        ret.put("changedBy", ConversionUtil.getPropertyWithRepresentation(person, "changedBy", Representation.REF));
-        ret.put("dateChanged", ConversionUtil.convertToRepresentation(person.getDateChanged(), Representation.DEFAULT));
-        if (person.isVoided()) {
-            ret.put("voidedBy", ConversionUtil.getPropertyWithRepresentation(person, "voidedBy", Representation.REF));
-            ret.put("dateVoided", ConversionUtil.convertToRepresentation(person.getDateVoided(), Representation.DEFAULT));
-            ret.put("voidReason", ConversionUtil.convertToRepresentation(person.getVoidReason(), Representation.DEFAULT));
-        }
         return ret;
     }
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
@@ -22,12 +22,12 @@ import java.util.Set;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.poi.hssf.record.formula.functions.T;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.util.ReflectionUtil;
-import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.RestUtil;
@@ -105,7 +105,7 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 			description.addProperty("proficientLocales");
 			description.addProperty("secretQuestion");
 			description.addProperty("retired");
-			description.addProperty("auditInfo", findMethod("getAuditInfo"));
+			description.addProperty("auditInfo");
 			description.addSelfLink();
 			return description;
 		}
@@ -362,19 +362,9 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 	 * 
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource#getAuditInfo(java.lang.Object)
 	 */
-	@Override
+	@PropertyGetter("auditInfo")
 	public SimpleObject getAuditInfo(UserAndPassword1_8 delegate) throws Exception {
-		User user = delegate.getUser();
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(user, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(user.getDateCreated(), Representation.DEFAULT));
-		if (user.isRetired()) {
-			ret.put("retiredBy", ConversionUtil.getPropertyWithRepresentation(user, "retiredBy", Representation.REF));
-			ret.put("dateRetired", ConversionUtil.convertToRepresentation(user.getDateRetired(), Representation.DEFAULT));
-			ret.put("retireReason", ConversionUtil.convertToRepresentation(user.getRetireReason(), Representation.DEFAULT));
-		}
-		ret.put("changedBy", ConversionUtil.getPropertyWithRepresentation(user, "changedBy", Representation.REF));
-		ret.put("dateChanged", ConversionUtil.convertToRepresentation(user.getDateChanged(), Representation.DEFAULT));
+		SimpleObject ret = super.getAuditInfo(delegate.getUser());
 		return ret;
 	}
 	

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
@@ -15,8 +15,6 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptReferenceTermMap;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -104,15 +102,6 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 		        + conceptReferenceTermMap.getTermA().getCode() + " - "
 		        + conceptReferenceTermMap.getTermB().getConceptSource().getName() + ": "
 		        + conceptReferenceTermMap.getTermB().getCode();
-	}
-	
-	public SimpleObject getAuditInfo(ConceptReferenceTermMap delegate) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(delegate, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(delegate.getDateCreated(), Representation.DEFAULT));
-		ret.put("changedBy", ConversionUtil.getPropertyWithRepresentation(delegate, "changedBy", Representation.REF));
-		ret.put("dateChanged", ConversionUtil.convertToRepresentation(delegate.getDateChanged(), Representation.DEFAULT));
-		return ret;
 	}
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
@@ -37,6 +37,9 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.Auditable;
+import org.openmrs.Retireable;
+import org.openmrs.Voidable;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -456,4 +459,41 @@ public class ConversionUtil {
 		
 		return result;
 	}
+	
+	/**
+	 * Gets extra book-keeping info, for the full representation
+	 * 
+	 * @param delegate
+	 * @return
+	 */
+	public static SimpleObject getAuditInfo(Object delegate) {
+		SimpleObject ret = new SimpleObject();
+		
+		if (delegate instanceof Auditable) {
+			Auditable auditable = (Auditable) delegate;
+			ret.put("creator", getPropertyWithRepresentation(auditable, "creator", Representation.REF));
+			ret.put("dateCreated",convertToRepresentation(auditable.getDateCreated(), Representation.DEFAULT));
+			ret.put("changedBy", getPropertyWithRepresentation(auditable, "changedBy", Representation.REF));
+			ret.put("dateChanged", convertToRepresentation(auditable.getDateChanged(), Representation.DEFAULT));
+		}
+		if (delegate instanceof Retireable) {
+			Retireable retireable = (Retireable) delegate;
+			if (retireable.isRetired()) {
+				ret.put("retiredBy", getPropertyWithRepresentation(retireable, "retiredBy", Representation.REF));
+				ret.put("dateRetired", convertToRepresentation(retireable.getDateRetired(), Representation.DEFAULT));
+				ret.put("retireReason", convertToRepresentation(retireable.getRetireReason(), Representation.DEFAULT));
+			}
+		}
+		if (delegate instanceof Voidable) {
+			Voidable voidable = (Voidable) delegate;
+			if (voidable.isVoided()) {
+				ret.put("voidedBy", getPropertyWithRepresentation(voidable, "voidedBy", Representation.REF));
+				ret.put("dateVoided", convertToRepresentation(voidable.getDateVoided(), Representation.DEFAULT));
+				ret.put("voidReason", convertToRepresentation(voidable.getVoidReason(), Representation.DEFAULT));
+			}
+		}
+		
+		return ret;
+	}
+	
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -41,6 +41,7 @@ import org.openmrs.module.webservices.rest.util.ReflectionUtil;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.RepHandler;
 import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
 import org.openmrs.module.webservices.rest.web.api.RestService;
@@ -54,7 +55,6 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
-
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 
@@ -850,4 +850,16 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		}
 		throw new RuntimeException(getClass() + " needs a @Resource or @SubResource annotation");
 	}
+	
+	/**
+	 * Gets the audit information of a resource.
+	 * 
+	 * @param resource the resource.
+	 * @return a {@link SimpleObject} with the audit information.
+	 */
+	@PropertyGetter("auditInfo")
+	protected SimpleObject getAuditInfo(Object resource) {
+		return ConversionUtil.getAuditInfo(resource);
+	}
+	
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
@@ -18,8 +18,10 @@ import org.openmrs.OpenmrsMetadata;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.util.ReflectionUtil;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.RepHandler;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
@@ -123,5 +125,16 @@ public abstract class BaseDelegatingSubclassHandler<Superclass, Subclass extends
 		}
 		rep.addSelfLink();
 		return getResource().convertDelegateToRepresentation(delegate, rep);
+	}
+	
+	/**
+	 * Gets the audit information of a resource.
+	 * 
+	 * @param resource the resource.
+	 * @return a {@link SimpleObject} with the audit information.
+	 */
+	@PropertyGetter("auditInfo")
+	protected SimpleObject getAuditInfo(Object resource) {
+		return ConversionUtil.getAuditInfo(resource);
 	}
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DataDelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DataDelegatingCrudResource.java
@@ -15,11 +15,9 @@ package org.openmrs.module.webservices.rest.web.resource.impl;
 
 import org.openmrs.OpenmrsData;
 import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.annotation.RepHandler;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
-import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 
 /**
@@ -47,20 +45,6 @@ public abstract class DataDelegatingCrudResource<T extends OpenmrsData> extends 
 		ret.put("display", delegate.toString());
 		ret.put("voided", delegate.isVoided());
 		ret.put("links", "[ All Data resources need to define their representations ]");
-		return ret;
-	}
-	
-	public SimpleObject getAuditInfo(T delegate) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(delegate, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(delegate.getDateCreated(), Representation.DEFAULT));
-		ret.put("changedBy", ConversionUtil.getPropertyWithRepresentation(delegate, "changedBy", Representation.REF));
-		ret.put("dateChanged", ConversionUtil.convertToRepresentation(delegate.getDateChanged(), Representation.DEFAULT));
-		if (delegate.isVoided()) {
-			ret.put("voidedBy", ConversionUtil.getPropertyWithRepresentation(delegate, "voidedBy", Representation.REF));
-			ret.put("dateVoided", ConversionUtil.convertToRepresentation(delegate.getDateVoided(), Representation.DEFAULT));
-			ret.put("voidReason", ConversionUtil.convertToRepresentation(delegate.getVoidReason(), Representation.DEFAULT));
-		}
 		return ret;
 	}
 	

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingSubResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingSubResource.java
@@ -13,11 +13,11 @@
  */
 package org.openmrs.module.webservices.rest.web.resource.impl;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openmrs.Auditable;
-import org.openmrs.BaseOpenmrsObject;
-import org.openmrs.Voidable;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
@@ -35,9 +35,6 @@ import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.util.ReflectionUtils;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 /**
  * Base implementation of a sub-resource of a DelegatingCrudResource that delegates to a domain
@@ -241,25 +238,4 @@ public abstract class DelegatingSubResource<T, P, PR extends DelegatingCrudResou
 		return convertDelegateToRepresentation(delegate, description);
 	}
 	
-	/**
-	 * Gets the audit information of a resource.
-	 * 
-	 * @param resource the resource.
-	 * @return a {@link SimpleObject} with the audit information.
-	 * @throws Exception
-	 */
-	public SimpleObject getAuditInfo(BaseOpenmrsObject resource) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(resource, "creator", Representation.REF));
-		ret.put("dateCreated",
-		    ConversionUtil.convertToRepresentation(((Auditable) resource).getDateCreated(), Representation.DEFAULT));
-		if (resource instanceof Voidable && ((Voidable) resource).isVoided()) {
-			ret.put("voidedBy", ConversionUtil.getPropertyWithRepresentation(resource, "voidedBy", Representation.REF));
-			ret.put("dateVoided",
-			    ConversionUtil.convertToRepresentation(((Voidable) resource).getDateVoided(), Representation.DEFAULT));
-			ret.put("voidReason",
-			    ConversionUtil.convertToRepresentation(((Voidable) resource).getVoidReason(), Representation.DEFAULT));
-		}
-		return ret;
-	}
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang.StringUtils;
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -27,7 +26,6 @@ import org.openmrs.module.webservices.rest.web.annotation.RepHandler;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
-import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
@@ -74,21 +72,6 @@ public abstract class MetadataDelegatingCrudResource<T extends OpenmrsMetadata> 
 		rep.addProperty("auditInfo", findMethod("getAuditInfo"));
 		rep.addSelfLink();
 		return convertDelegateToRepresentation(delegate, rep);
-	}
-	
-	public SimpleObject getAuditInfo(T delegate) throws Exception {
-		SimpleObject ret = new SimpleObject();
-		ret.put("creator", ConversionUtil.getPropertyWithRepresentation(delegate, "creator", Representation.REF));
-		ret.put("dateCreated", ConversionUtil.convertToRepresentation(delegate.getDateCreated(), Representation.DEFAULT));
-		if (delegate.isRetired()) {
-			ret.put("retiredBy", ConversionUtil.getPropertyWithRepresentation(delegate, "retiredBy", Representation.REF));
-			ret.put("dateRetired", ConversionUtil.convertToRepresentation(delegate.getDateRetired(), Representation.DEFAULT));
-			ret.put("retireReason",
-			    ConversionUtil.convertToRepresentation(delegate.getRetireReason(), Representation.DEFAULT));
-		}
-		ret.put("changedBy", ConversionUtil.getPropertyWithRepresentation(delegate, "changedBy", Representation.REF));
-		ret.put("dateChanged", ConversionUtil.convertToRepresentation(delegate.getDateChanged(), Representation.DEFAULT));
-		return ret;
 	}
 	
 	/**


### PR DESCRIPTION
https://issues.openmrs.org/browse/RESTWS-536

Audit info attributes are obtained in a single utilitty method and used in the base classes of resources. There is no a single ancestor for all resources, that's why I had to put it in a utility class.