### PR TITLE
Fix for: RESTWS-419 - WSD-DATE date parsing not quite ISO8601 compatible

### DIFF
--- a/omod-common/pom.xml
+++ b/omod-common/pom.xml
@@ -17,6 +17,12 @@
 		      <version>6.0.18</version>
 		      <scope>provided</scope>
 	     </dependency>
+		
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.9.2</version>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
@@ -37,6 +37,8 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
 import org.openmrs.Auditable;
 import org.openmrs.Retireable;
 import org.openmrs.Voidable;
@@ -238,15 +240,15 @@ public class ConversionUtil {
 
 
 			if (toClass.isAssignableFrom(Date.class)) {
-				ParseException pex = null;
+				IllegalArgumentException pex = null;
 				String[] supportedFormats = {"yyyy-MM-dd'T'HH:mm:ss.SSSZ", "yyyy-MM-dd'T'HH:mm:ss.SSS",
 						"yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ssXXX", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd"};
 				for (int i = 0; i < supportedFormats.length; i++) {
 					try {
-						Date date = new SimpleDateFormat(supportedFormats[i]).parse(string);
+						Date date = DateTime.parse(string, DateTimeFormat.forPattern(supportedFormats[i])).toDate();
 						return date;
 					}
-					catch (ParseException ex) {
+					catch (IllegalArgumentException ex) {
 						pex = ex;
 					}
 				}

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtilTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtilTest.java
@@ -54,19 +54,28 @@ public class ConversionUtilTest extends BaseModuleWebContextSensitiveTest {
 			Assert.assertEquals(result, expected);
 		}
 	}
+	
 	/**
 	 * @see ConversionUtil#convert(Object,Type)
 	 * @verifies String to Date conversion for multiple formatted date/dateTime strings having timezone
 	 */
 	@Test
 	public void convert_shouldReturnCorrectDateWhenParsingStringHavingTimeZone() throws Exception {
-		Date expectedDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse("2016-01-12T06:00:00+0530");
-
-		String[] dates = {"2016-01-12T06:00:00+05:30", "2016-01-12T06:00:00+0530"};
-
-		for (String date : dates) {
+		Date expectedDate1 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse("2016-01-12T06:00:00+0530");
+		//Added to check against more ISO8601 format dates im 'dates2' array
+		Date expectedDate2 = (Date) ConversionUtil.convert("2014-02-20T11:00:00.000-0500", Date.class);
+		
+		String[] dates1 = {"2016-01-12T06:00:00+05:30", "2016-01-12T06:00:00+0530"};
+		String[] dates2 = { "2014-02-20T11:00:00.000-05:00", "2014-02-20T11:00:00.000-05" };
+		
+		for (String date : dates1) {
 			Date actualDate = (Date) ConversionUtil.convert(date, Date.class);
-			Assert.assertEquals(expectedDate, actualDate);
+			Assert.assertEquals(expectedDate1, actualDate);
+		}
+		
+		for (String date : dates2) {
+			Date actualDate = (Date) ConversionUtil.convert(date, Date.class);
+			Assert.assertEquals(expectedDate2, actualDate);
 		}
 	}
 	


### PR DESCRIPTION
**Issue**: [RESTWS-419](https://issues.openmrs.org/browse/RESTWS-419)

**Fix**: Replace the the non ISO8601 `SimpleDateFormat` in Java with the `DateTime` class parser which is a part of the [Joda-Time] (http://www.joda.org/joda-time/) public library. This parses ISO compliant dates correctly and fixes the issue where TimeZones were being dropped.
A relevant Unit Test has also been added