### PR TITLE
RESTWS-599 Fix updating concept's mappings

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -13,23 +13,17 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
-
-import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang.StringUtils;
-import org.openmrs.*;
+import org.openmrs.Concept;
+import org.openmrs.ConceptAnswer;
+import org.openmrs.ConceptClass;
+import org.openmrs.ConceptDatatype;
+import org.openmrs.ConceptDescription;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptName;
+import org.openmrs.ConceptNumeric;
+import org.openmrs.ConceptSearchResult;
+import org.openmrs.Drug;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.helper.HibernateCollectionHelper;
@@ -55,6 +49,19 @@ import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.util.LocaleUtility;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * {@link Resource} for {@link Concept}, supporting standard CRUD operations
@@ -340,27 +347,30 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 			}
 		}.set(descriptions);
 	}
-	
+
 	/**
-	 * It's needed, because of ConversionException: Don't know how to handle collection class:
-	 * interface java.util.Collection
-	 *
-	 * @param instance
-	 * @param mappings
-	 */
+	* It's needed, because of ConversionException: Don't know how to handle collection class:
+	* interface java.util.Collection
+	*
+	* @param instance
+	* @param mappings
+	*/
 	@PropertySetter("mappings")
 	public static void setMappings(Concept instance, List<ConceptMap> mappings) {
-		instance.setConceptMappings(mappings);
+		instance.getConceptMappings().clear();
+		for (ConceptMap map : mappings) {
+			instance.addConceptMapping(map);
+		}
 	}
-	
+
 	@PropertyGetter("mappings")
 	public static List<ConceptMap> getMappings(Concept instance) {
 		return new ArrayList<ConceptMap>(instance.getConceptMappings());
 	}
-	
+
 	/**
 	 * Gets the display name of the Concept delegate
-	 * 
+	 *
 	 * @param instance the delegate instance to get the display name off
 	 */
 	@PropertyGetter("display")

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_8Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_8Test.java
@@ -13,17 +13,6 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_9;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,7 +20,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
+import org.openmrs.ConceptMap;
 import org.openmrs.ConceptName;
+import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptSet;
 import org.openmrs.Drug;
 import org.openmrs.api.APIException;
@@ -47,6 +38,17 @@ import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceContr
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests functionality of {@link ConceptController}. This does not use @should annotations because
@@ -390,6 +392,50 @@ public class ConceptController1_8Test extends MainResourceControllerTest {
 		Assert.assertTrue(hasAnswer(concept, answer1));
 		Assert.assertTrue(hasAnswer(concept, answer2));
 		Assert.assertEquals(2, concept.getAnswers().size());
+	}
+
+	@Test
+	public void shouldSetMappingsOnConcept() throws Exception {
+		//before adding
+		Concept concept = service.getConceptByUuid(getUuid());
+		assertThat(concept.getConceptMappings().size(), is(0));
+
+		//add one mapping
+		MockHttpServletRequest request = request(RequestMethod.POST, getURI() + "/" + getUuid());
+		ConceptReferenceTerm referenceTerm = service.getAllConceptReferenceTerms().get(0);
+		String mapTypeUuid = service.getDefaultConceptMapType().getUuid();
+		String json = "{ \"mappings\": [{\"conceptReferenceTerm\":\""+referenceTerm.getUuid()+"\",\"conceptMapType\":\""+mapTypeUuid+"\"}]}";
+		request.setContent(json.getBytes());
+
+		handle(request);
+
+		concept = service.getConceptByUuid(getUuid());
+		assertThat(concept.getConceptMappings().size(), is(1));
+		assertThat(hasMappingToTerm(concept, referenceTerm), is(true));
+
+		//set mappings to empty
+		MockHttpServletRequest requestEmpty = request(RequestMethod.POST, getURI() + "/" + getUuid());
+		String jsonEmpty = "{ \"mappings\": []}";
+		requestEmpty.setContent(jsonEmpty.getBytes());
+
+		handle(requestEmpty);
+
+		assertThat(concept.getConceptMappings().size(), is(0));
+	}
+	/**
+	 * Convenience helper method to look for the given mapping amongst the mappings on concept
+	 *
+	 * @param concept the concept to be checked
+	 * @param term the reference term, which is searched for in mappings
+	 * @return true if the term is found in mappings of the concept
+	 */
+	private boolean hasMappingToTerm(Concept concept, ConceptReferenceTerm term){
+		for(ConceptMap map : concept.getConceptMappings()){
+			if(map.getConceptReferenceTerm().equals(term)){
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Test


### PR DESCRIPTION
This pull request fixes ClassCastException by changing argument type. Clearing list and adding mappings one by one instead of straightforward setting new Set is necessary to avoid hibernate errors with deleting orphans.