### PR TITLE
RESTWS 599 fix updating concept's mapping and ObsResource save method

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -13,23 +13,17 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
-
-import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang.StringUtils;
-import org.openmrs.*;
+import org.openmrs.Concept;
+import org.openmrs.ConceptAnswer;
+import org.openmrs.ConceptClass;
+import org.openmrs.ConceptDatatype;
+import org.openmrs.ConceptDescription;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptName;
+import org.openmrs.ConceptNumeric;
+import org.openmrs.ConceptSearchResult;
+import org.openmrs.Drug;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.helper.HibernateCollectionHelper;
@@ -55,6 +49,19 @@ import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.util.LocaleUtility;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * {@link Resource} for {@link Concept}, supporting standard CRUD operations
@@ -340,27 +347,30 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 			}
 		}.set(descriptions);
 	}
-	
+
 	/**
-	 * It's needed, because of ConversionException: Don't know how to handle collection class:
-	 * interface java.util.Collection
-	 *
-	 * @param instance
-	 * @param mappings
-	 */
+	* It's needed, because of ConversionException: Don't know how to handle collection class:
+	* interface java.util.Collection
+	*
+	* @param instance
+	* @param mappings
+	*/
 	@PropertySetter("mappings")
 	public static void setMappings(Concept instance, List<ConceptMap> mappings) {
-		instance.setConceptMappings(mappings);
+		instance.getConceptMappings().clear();
+		for (ConceptMap map : mappings) {
+			instance.addConceptMapping(map);
+		}
 	}
-	
+
 	@PropertyGetter("mappings")
 	public static List<ConceptMap> getMappings(Concept instance) {
 		return new ArrayList<ConceptMap>(instance.getConceptMappings());
 	}
-	
+
 	/**
 	 * Gets the display name of the Concept delegate
-	 * 
+	 *
 	 * @param instance the delegate instance to get the display name off
 	 */
 	@PropertyGetter("display")

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -176,7 +176,8 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> {
 	 */
 	@Override
 	public Obs save(Obs delegate) {
-		return Context.getObsService().saveObs(delegate, "REST web service");
+		Obs savedObs = Context.getObsService().saveObs(delegate, "REST web service");
+		return Context.getObsService().getObs(savedObs.getId());
 	}
 	
 	/**


### PR DESCRIPTION
This PR contains #216 which was reverted in #218 + it fixes bug in ObsResource1_8 save method, which  sometimes caused [lazy initialization errors](https://ci.openmrs.org/browse/RESTWS-RESTWS-JOB1-583/test/case/77595067), and was reason why #216 was reverted in first place.