### PR TITLE
💲 RESTWS-579: Ensure both legacy UI and Swagger can access jQuery

### DIFF
--- a/omod/src/main/webapp/apiDocs.jsp
+++ b/omod/src/main/webapp/apiDocs.jsp
@@ -1,6 +1,9 @@
-<% request.setAttribute("DO_NOT_INCLUDE_JQUERY", true); %>
 <%@ include file="/WEB-INF/template/include.jsp"%>
 <%@ include file="/WEB-INF/template/header.jsp"%>
+
+<script type="text/javascript">
+  var $ = jQuery; // required because the legacy UI uses jQuery.noConflict() and Swagger requires the $ variable
+</script>
 
 <link rel="icon" type="image/png" href="<openmrs:contextPath/>/moduleResources/webservices/rest/js/swagger-ui/dist/images/favicon-32x32.png" sizes="32x32" />
 <link rel="icon" type="image/png" href="<openmrs:contextPath/>/moduleResources/webservices/rest/js/swagger-ui/dist/images/favicon-16x16.png" sizes="16x16" />
@@ -8,7 +11,6 @@
 <link href="<openmrs:contextPath/>/moduleResources/webservices/rest/js/swagger-ui/dist/css/reset.css" media="screen" rel="stylesheet" type="text/css"/>
 <link href="<openmrs:contextPath/>/moduleResources/webservices/rest/js/swagger-ui/dist/css/screen.css" media="screen" rel="stylesheet" type="text/css"/>
 
-<openmrs:htmlInclude file="/moduleResources/webservices/rest/js/swagger-ui/dist/lib/jquery-1.8.0.min.js"/>
 <openmrs:htmlInclude file="/moduleResources/webservices/rest/js/swagger-ui/dist/lib/jquery.slideto.min.js"/>
 <openmrs:htmlInclude file="/moduleResources/webservices/rest/js/swagger-ui/dist/lib/jquery.wiggle.min.js"/>
 <openmrs:htmlInclude file="/moduleResources/webservices/rest/js/swagger-ui/dist/lib/jquery.ba-bbq.min.js"/>


### PR DESCRIPTION
Previously, Swagger UI was including its own copy of jQuery (and preventing OpenMRS from including a copy). This caused code generated by the header in the legacy UI to fall over💥.

This PR changes things so that the default jQuery provided by the legacy UI is used instead. However, since Swagger UI expects the 💲 variable to exist, we also have to do the following hack because the legacy UI uses `jQuery.noConflict()`:

```js
var $ = jQuery; 
```