### PR TITLE
RESTWS-609 Cleanup smell of exception as control flow using ModuleUtil

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
@@ -14,8 +14,6 @@
 package org.openmrs.module.webservices.rest.web.api.impl;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,13 +23,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.proxy.HibernateProxy;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.ModuleException;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.module.webservices.rest.web.OpenmrsClassScanner;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -241,12 +236,10 @@ public class RestServiceImpl implements RestService {
 					boolean supported = false;
 					
 					for (String supportedVersion : supportedOpenmrsVersions) {
-						try {
-							ModuleUtil.checkRequiredVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT, supportedVersion);
+						if (ModuleUtil.matchRequiredVersions(OpenmrsConstants.OPENMRS_VERSION_SHORT, supportedVersion)) {
 							supported = true;
 							continue;
 						}
-						catch (Exception e) {}
 					}
 					
 					if (!supported) {
@@ -262,12 +255,10 @@ public class RestServiceImpl implements RestService {
 					boolean supported = false;
 					
 					for (String supportedVersion : supportedOpenmrsVersions) {
-						try {
-							ModuleUtil.checkRequiredVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT, supportedVersion);
+						if (ModuleUtil.matchRequiredVersions(OpenmrsConstants.OPENMRS_VERSION_SHORT, supportedVersion)) {
 							supported = true;
 							continue;
 						}
-						catch (Exception e) {}
 					}
 					
 					if (!supported) {

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -136,7 +136,7 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 				if (annotation != null) {
 					String[] supportedOpenmrsVersions = annotation.supportedOpenmrsVersions();
 					for (String version : supportedOpenmrsVersions) {
-						if (versionMatches(version)) {
+						if (ModuleUtil.matchRequiredVersions(OpenmrsConstants.OPENMRS_VERSION_SHORT, version)) {
 							tmpSubclassHandlers.add(handler);
 							break;
 						}
@@ -150,16 +150,6 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		}
 		
 		subclassHandlers = tmpSubclassHandlers;
-	}
-	
-	private boolean versionMatches(String supportedVersion) {
-		try {
-			ModuleUtil.checkRequiredVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT, supportedVersion);
-		}
-		catch (Exception e) {
-			return false;
-		}
-		return true;
 	}
 	
 	/**

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/test/OpenmrsProfileRule.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/test/OpenmrsProfileRule.java
@@ -77,12 +77,10 @@ public class OpenmrsProfileRule implements TestRule {
 		@Override
 		public void evaluate() throws Throwable {
 			for (String openmrsVersion : openmrsVersions) {
-				try {
-					ModuleUtil.checkRequiredVersion(OpenmrsConstants.OPENMRS_VERSION_SHORT, openmrsVersion);
+				if (ModuleUtil.matchRequiredVersions(OpenmrsConstants.OPENMRS_VERSION_SHORT, openmrsVersion)) {
 					base.evaluate();
 					return;
 				}
-				catch (Exception e) {}
 			}
 			System.out.println("Ignored " + description.getMethodName() + " (run only on OpenMRS "
 			        + StringUtils.join(openmrsVersions, ",") + ")");


### PR DESCRIPTION
replace try/catch block used to check if SearchHandler supports given
OpenMRS

version by an if statement and the ModuleUtil method returning a boolean if
version is supported.

see https://issues.openmrs.org/browse/RESTWS-609