### PR TITLE
RESTWS-610 Test helper RestServiceImpl.addSupportedSearchHandler() sh…

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/RestHelperService.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/RestHelperService.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 import org.openmrs.ConceptMap;
 import org.openmrs.Patient;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchHandler;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubclassHandler;
 
 /**
  * It is provided as a workaround for missing API methods to fetch {@link ConceptMap}, etc.
@@ -32,6 +34,10 @@ public interface RestHelperService {
 	<T> List<T> getObjectsByFields(Class<? extends T> type, Field... fields);
 	
 	List<Patient> getPatients(Collection<Integer> patientIds);
+	
+	List<SearchHandler> getRegisteredSearchHandlers();
+	
+	List<DelegatingSubclassHandler> getRegisteredRegisteredSubclassHandlers();
 	
 	public static class Field {
 		

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestHelperServiceImpl.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestHelperServiceImpl.java
@@ -25,9 +25,14 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.webservices.rest.web.api.RestHelperService;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchHandler;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubclassHandler;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.openmrs.api.context.Context.getRegisteredComponents;
 
 /**
  * REST helper service, which must not be used outside of the REST module.
@@ -122,5 +127,23 @@ public class RestHelperServiceImpl extends BaseOpenmrsService implements RestHel
 		}
 		
 		return ret;
+	}
+
+	/**
+	 * @see RestHelperService#getRegisteredSearchHandlers()
+	 */
+	@Override
+	public List<SearchHandler> getRegisteredSearchHandlers() {
+		final List<SearchHandler> result = Context.getRegisteredComponents(SearchHandler.class);
+		return result != null ? result : new ArrayList<SearchHandler>();
+	}
+
+	/**
+	 * @see RestHelperService#getRegisteredRegisteredSubclassHandlers()
+	 */
+	@Override
+	public List<DelegatingSubclassHandler> getRegisteredRegisteredSubclassHandlers() {
+		final List<DelegatingSubclassHandler> result = getRegisteredComponents(DelegatingSubclassHandler.class);
+		return result != null ? result : new ArrayList<DelegatingSubclassHandler>();
 	}
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
@@ -26,11 +26,11 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.proxy.HibernateProxy;
 import org.openmrs.api.APIException;
-import org.openmrs.api.context.Context;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.module.webservices.rest.web.OpenmrsClassScanner;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.SubResource;
+import org.openmrs.module.webservices.rest.web.api.RestHelperService;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.NamedRepresentation;
@@ -61,6 +61,16 @@ public class RestServiceImpl implements RestService {
 	
 	private volatile List<SearchHandler> allSearchHandlers;
 	
+	private RestHelperService restHelperService;
+
+	public RestHelperService getRestHelperService() {
+		return restHelperService;
+	}
+
+	public void setRestHelperService(RestHelperService restHelperService) {
+		this.restHelperService = restHelperService;
+	}
+
 	public RestServiceImpl() {
 	}
 	
@@ -168,22 +178,6 @@ public class RestServiceImpl implements RestService {
 			return true;
 		}
 		
-	}
-	
-	/**
-	 * It should be used in TESTS ONLY.
-	 * 
-	 * @param searchHandler
-	 */
-	void addSupportedSearchHandler(SearchHandler searchHandler) {
-		if (searchHandlersByIds == null) {
-			searchHandlersByIds = new HashMap<RestServiceImpl.SearchHandlerIdKey, SearchHandler>();
-		}
-		if (searchHandlersByParameter == null) {
-			searchHandlersByParameter = new HashMap<SearchHandlerParameterKey, Set<SearchHandler>>();
-		}
-		
-		addSupportedSearchHandler(searchHandlersByIds, searchHandlersByParameter, searchHandler);
 	}
 	
 	private void initializeResources() {
@@ -302,7 +296,7 @@ public class RestServiceImpl implements RestService {
 		Map<SearchHandlerParameterKey, Set<SearchHandler>> tempSearchHandlersByParameters = new HashMap<SearchHandlerParameterKey, Set<SearchHandler>>();
 		Map<String, Set<SearchHandler>> tempSearchHandlersByResource = new HashMap<String, Set<SearchHandler>>();
 		
-		List<SearchHandler> allSearchHandlers = Context.getRegisteredComponents(SearchHandler.class);
+		List<SearchHandler> allSearchHandlers = restHelperService.getRegisteredSearchHandlers();
 		for (SearchHandler searchHandler : allSearchHandlers) {
 			addSearchHandler(tempSearchHandlersByIds, tempSearchHandlersByParameters, tempSearchHandlersByResource,
 			    searchHandler);
@@ -553,11 +547,8 @@ public class RestServiceImpl implements RestService {
 			}
 		}
 		
-		@SuppressWarnings("rawtypes")
-		List<DelegatingSubclassHandler> subclassHandlers = Context.getRegisteredComponents(DelegatingSubclassHandler.class);
-		
-		for (@SuppressWarnings("rawtypes")
-		DelegatingSubclassHandler subclassHandler : subclassHandlers) {
+		List<DelegatingSubclassHandler> subclassHandlers = restHelperService.getRegisteredRegisteredSubclassHandlers();
+		for (DelegatingSubclassHandler subclassHandler : subclassHandlers) {
 			resourceHandlers.add(subclassHandler);
 		}
 		

--- a/omod-common/src/main/resources/webModuleApplicationContext.xml
+++ b/omod-common/src/main/resources/webModuleApplicationContext.xml
@@ -17,8 +17,9 @@
 		</property>
 		<property name="target">
 			<bean
-				class="org.openmrs.module.webservices.rest.web.api.impl.RestServiceImpl"
-				autowire="byType" />
+				class="org.openmrs.module.webservices.rest.web.api.impl.RestServiceImpl">
+				<property name="restHelperService" ref="restHelperService"></property>
+			</bean>
 		</property>
 		<property name="preInterceptors">
 			<ref bean="serviceInterceptors" />


### PR DESCRIPTION
…ould not

be in RestServiceImpl

* move Context.getRegisteredComponents calls into add RestHelperService methods
* remove RestServiceImpl.addSupportedSearchHandler()
* add RestHelperService dependency to RestServiceImpl
* mock RestHelperService in RestServiceImplTest

see https://issues.openmrs.org/browse/RESTWS-610


NOTE: this is just a first stab at the issue. please comment :)