### PR TITLE
RESTWS-584 Add jacoco + coveralls.io test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
 jdk:
  - oraclejdk8
+after_success:
+  - mvn jacoco:report coveralls:report

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/openmrs/openmrs-module-webservices.rest.svg?branch=master)](https://travis-ci.org/openmrs/openmrs-module-webservices.rest)
+[![Build Status](https://travis-ci.org/openmrs/openmrs-module-webservices.rest.svg?branch=master)](https://travis-ci.org/openmrs/openmrs-module-webservices.rest) [![Coverage
+Status](https://coveralls.io/repos/github/openmrs/openmrs-module-webservices.rest/badge.svg?branch=master)](https://coveralls.io/github/openmrs/openmrs-module-webservices.rest?branch=master)
 
 <img src="https://talk.openmrs.org/uploads/default/original/2X/f/f1ec579b0398cb04c80a54c56da219b2440fe249.jpg" alt="OpenMRS"/>
 

--- a/omod-common/pom.xml
+++ b/omod-common/pom.xml
@@ -78,6 +78,10 @@
                 <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
                 <artifactId>maven-java-formatter-plugin</artifactId>
             </plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -133,6 +133,10 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,29 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.7.7.201606060606</version>
+					<configuration>
+						<includes>
+							<include>org/openmrs/**</include>
+						</includes>
+					</configuration>
+					<executions>
+						<execution>
+							<id>prepare-agent</id>
+							<goals>
+								<goal>prepare-agent</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.eluder.coveralls</groupId>
+					<artifactId>coveralls-maven-plugin</artifactId>
+					<version>4.2.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
* add jacoco maven plugin for generating coverage reports
* add coveralls maven plugin to send jacoco reports to coveralls.io
* add travis after_success command to send jacoco reports to coveralls.io after
successful builds
* jacoco and coverals are configured in root pom pluginmanagement
* added coverage badge to README

* jacoco only generates coverage for omod and omod-common for now since omod-1.8, omod-1.9, ...
do not have a build section in their pom.xml

see https://issues.openmrs.org/browse/RESTWS-584