### PR TITLE
RESTWS-584 Add coverage to omod-1.8, ... modules

### DIFF
--- a/omod-1.10/pom.xml
+++ b/omod-1.10/pom.xml
@@ -91,4 +91,13 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/omod-1.11/pom.xml
+++ b/omod-1.11/pom.xml
@@ -116,4 +116,13 @@
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/omod-1.12/pom.xml
+++ b/omod-1.12/pom.xml
@@ -130,4 +130,13 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/omod-1.8/pom.xml
+++ b/omod-1.8/pom.xml
@@ -63,4 +63,12 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/omod-1.9/pom.xml
+++ b/omod-1.9/pom.xml
@@ -77,4 +77,13 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/omod-2.0/pom.xml
+++ b/omod-2.0/pom.xml
@@ -137,4 +137,13 @@
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
* add build/plugin section to the maven submodules omod-1.8, omod-1.9,...
so coverage reports are also generated for them

see https://issues.openmrs.org/browse/RESTWS-584