### PR TITLE
RESTWS-618 Formatter config forces CRLF line endings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,6 @@
 						<compilerTargetPlatform>${javaCompilerVersion}</compilerTargetPlatform>
 						<configFile>../OpenMRSFormatter.xml</configFile>
 						<overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
-						<lineEnding>CRLF</lineEnding>
 					</configuration>
 					<executions>
 						<execution>


### PR DESCRIPTION
formatter should not enforce line endings.

line endings are specific to the devs environment and are handled by git on checkout.

see https://issues.openmrs.org/browse/RESTWS-618