### PR TITLE
RESTWS-619 Add SearchConfigTest

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/api/SearchConfig.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/api/SearchConfig.java
@@ -30,49 +30,127 @@ public class SearchConfig {
 	
 	private final Set<SearchQuery> searchQueries;
 	
+	/**
+	 * Creates an instance of SearchConfig.
+	 * 
+	 * @param id the id of the search config
+	 * @param supportedResource the supported resource
+	 * @param supportedOpenmrsVersions the supported openmrs versions
+	 * @param searchQueries the search queries
+	 * @should create an instance of search config
+	 * @should fail if given id is null
+	 * @should fail if given id is empty
+	 * @should fail if given supported resource is null
+	 * @should fail if given supported resource is empty
+	 * @should fail if given supported openmrs versions is null
+	 * @should fail if given supported openmrs versions is empty
+	 * @should fail if given search queries is null
+	 * @should fail if given search queries is empty
+	 */
 	public SearchConfig(String id, String supportedResource, Collection<String> supportedOpenmrsVersions,
 	    Collection<SearchQuery> searchQueries) {
+		Validate.notEmpty(id, "id must not be empty");
+		Validate.notEmpty(supportedResource, "supportedResource must not be empty");
+		Validate.notEmpty(supportedOpenmrsVersions, "supportedOpenmrsVersions must not be empty");
+		Validate.notEmpty(searchQueries, "searchQueries must not be empty");
+		
 		this.id = id;
 		this.supportedResource = supportedResource;
 		this.supportedOpenmrsVersions = Collections.unmodifiableSet(new HashSet<String>(supportedOpenmrsVersions));
 		this.searchQueries = Collections.unmodifiableSet(new HashSet<SearchQuery>(searchQueries));
-		
-		Validate.notEmpty(this.id, "id must not be empty");
-		Validate.notEmpty(this.supportedResource, "supportedResource must not be empty");
-		Validate.notEmpty(this.supportedOpenmrsVersions, "supportedOpenmrsVersions must not be empty");
-		Validate.notEmpty(this.searchQueries, "searchQueries must not be empty");
 	}
 	
+	/**
+	 * Creates an instance of SearchConfig.
+	 * <p>
+	 * Delegates to {@link SearchConfig#SearchConfig(String, String, Collection, Collection)}.
+	 * </p>
+	 * 
+	 * @param id the id of the search config
+	 * @param supportedResource the supported resource
+	 * @param supportedOpenmrsVersion the supported openmrs version
+	 * @param searchQuery the search query
+	 * @should create an instance of search config
+	 */
 	public SearchConfig(String id, String supportedResource, String supportedOpenmrsVersion, SearchQuery searchQuery) {
 		this(id, supportedResource, Arrays.asList(supportedOpenmrsVersion), Arrays.asList(searchQuery));
 	}
 	
+	/**
+	 * Creates an instance of SearchConfig.
+	 * <p>
+	 * Delegates to {@link SearchConfig#SearchConfig(String, String, Collection, Collection)}.
+	 * </p>
+	 * 
+	 * @param id the id of the search config
+	 * @param supportedResource the supported resource
+	 * @param supportedOpenmrsVersions the supported openmrs versions
+	 * @param searchQuery the search query
+	 * @should create an instance of search config
+	 */
 	public SearchConfig(String id, String supportedResource, Collection<String> supportedOpenmrsVersions,
 	    SearchQuery searchQuery) {
 		this(id, supportedResource, supportedOpenmrsVersions, Arrays.asList(searchQuery));
 	}
 	
+	/**
+	 * Creates an instance of SearchConfig.
+	 * <p>
+	 * Delegates to {@link SearchConfig#SearchConfig(String, String, Collection, Collection)}.
+	 * </p>
+	 * 
+	 * @param id the id of the search config
+	 * @param supportedResource the supported resource
+	 * @param supportedOpenmrsVersion the supported openmrs version
+	 * @param searchQueries the search queries
+	 * @should create an instance of search config
+	 */
 	public SearchConfig(String id, String supportedResource, String supportedOpenmrsVersion,
 	    Collection<SearchQuery> searchQueries) {
 		this(id, supportedResource, Arrays.asList(supportedOpenmrsVersion), searchQueries);
 	}
 	
+	/**
+	 * Get this id.
+	 * 
+	 * @return this id
+	 */
 	public String getId() {
 		return id;
 	}
 	
+	/**
+	 * Get this {@code supportedResource}.
+	 * 
+	 * @return this supported resource
+	 */
 	public String getSupportedResource() {
 		return supportedResource;
 	}
 	
+	/**
+	 * Get this {@code supportedOpenmrsVersions}.
+	 * 
+	 * @return this supported openmrs versions
+	 */
 	public Set<String> getSupportedOpenmrsVersions() {
 		return supportedOpenmrsVersions;
 	}
 	
+	/**
+	 * Get this {@code searchQueries}.
+	 * 
+	 * @return this search queries
+	 */
 	public Set<SearchQuery> getSearchQueries() {
 		return searchQueries;
 	}
 	
+	/**
+	 * @see Object#hashCode()
+	 * @return the hash code
+	 * @should return same hashcode for equal search configs
+	 */
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -83,30 +161,39 @@ public class SearchConfig {
 		return result;
 	}
 	
+	/**
+	 * @see Object#equals(Object)
+	 * @param obj the object to test for if equal to this
+	 * @return true if obj is equal to this otherwise false
+	 * @should return true if given this
+	 * @should return true if this id and supported openmrs version and supported resource are equal
+	 *         to given search configs
+	 * @should be symmetric
+	 * @should be transitive
+	 * @should return false if given null
+	 * @should return false if given an object which is not an instanceof this class
+	 * @should return false if this id is not equal to the given search configs id
+	 * @should return false if this supported openmrs version is not equal to given search configs
+	 *         supported openmrs version
+	 * @should return false if this supported resource is not equal to given search configs
+	 *         supported resource
+	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
+		if (!(obj instanceof SearchConfig))
 			return false;
 		SearchConfig other = (SearchConfig) obj;
-		if (id == null) {
-			if (other.id != null)
-				return false;
-		} else if (!id.equals(other.id))
+		if (!id.equals(other.id)) {
 			return false;
-		if (supportedOpenmrsVersions == null) {
-			if (other.supportedOpenmrsVersions != null)
-				return false;
-		} else if (!supportedOpenmrsVersions.equals(other.supportedOpenmrsVersions))
+		}
+		if (!supportedOpenmrsVersions.equals(other.supportedOpenmrsVersions)) {
 			return false;
-		if (supportedResource == null) {
-			if (other.supportedResource != null)
-				return false;
-		} else if (!supportedResource.equals(other.supportedResource))
+		}
+		if (!supportedResource.equals(other.supportedResource)) {
 			return false;
+		}
 		return true;
 	}
 }

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/resource/api/SearchConfigTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/resource/api/SearchConfigTest.java
@@ -1,0 +1,412 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.resource.api;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link SearchConfig}.
+ */
+public class SearchConfigTest {
+	
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+	
+	/**
+	 * @verifies create an instance of search config
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldCreateAnInstanceOfSearchConfig() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by encounter").withRequiredParameters(
+		    "encounter").build();
+		SearchConfig searchConfig = new SearchConfig("default", "v1/order", asList("1.8.*", "1.9.*"), asList(searchQuery1,
+		    searchQuery2));
+		
+		assertThat(searchConfig.getId(), is("default"));
+		assertThat(searchConfig.getSupportedResource(), is("v1/order"));
+		assertThat(searchConfig.getSupportedOpenmrsVersions().size(), is(2));
+		assertThat(searchConfig.getSupportedOpenmrsVersions(), hasItem("1.8.*"));
+		assertThat(searchConfig.getSupportedOpenmrsVersions(), hasItem("1.9.*"));
+		assertThat(searchConfig.getSearchQueries().size(), is(2));
+		assertThat(searchConfig.getSearchQueries(), hasItem(searchQuery1));
+		assertThat(searchConfig.getSearchQueries(), hasItem(searchQuery2));
+	}
+	
+	/**
+	 * @verifies fail if given id is null
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenIdIsNull() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("id must not be empty");
+		String id = null;
+		new SearchConfig(id, "v1/order", asList("1.8.*"), asList(new SearchQuery.Builder("Enables to search")
+		        .withOptionalParameters("id").build()));
+	}
+	
+	/**
+	 * @verifies fail if given id is empty
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenIdIsEmpty() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("id must not be empty");
+		new SearchConfig("", "v1/order", asList("1.8.*"), asList(new SearchQuery.Builder("Enables to search")
+		        .withOptionalParameters("id").build()));
+	}
+	
+	/**
+	 * @verifies fail if given supported resource is null
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenSupportedResourceIsNull() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("supportedResource must not be empty");
+		String supportedResource = null;
+		new SearchConfig("default", supportedResource, asList("1.8.*"), asList(new SearchQuery.Builder("Enables to search")
+		        .withOptionalParameters("id").build()));
+	}
+	
+	/**
+	 * @verifies fail if given supported resource is empty
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenSupportedResourceIsEmpty() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("supportedResource must not be empty");
+		new SearchConfig("default", "", asList("1.8.*"), asList(new SearchQuery.Builder("Enables to search")
+		        .withOptionalParameters("id").build()));
+	}
+	
+	/**
+	 * @verifies fail if given supported openmrs versions is null
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenSupportedOpenmrsVersionsIsNull() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("supportedOpenmrsVersions must not be empty");
+		List<String> supportedOpenmrsVersions = null;
+		new SearchConfig("default", "v1/order", supportedOpenmrsVersions,
+		        asList(new SearchQuery.Builder("Enables to search").withOptionalParameters("id").build()));
+	}
+	
+	/**
+	 * @verifies fail if given supported openmrs versions is empty
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenSupportedOpenmrsVersionsIsEmpty() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("supportedOpenmrsVersions must not be empty");
+		List<String> supportedOpenmrsVersions = Collections.emptyList();
+		new SearchConfig("default", "v1/order", supportedOpenmrsVersions,
+		        asList(new SearchQuery.Builder("Enables to search").withOptionalParameters("id").build()));
+	}
+	
+	/**
+	 * @verifies fail if given search queries is null
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenSearchQueriesIsNull() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("searchQueries must not be empty");
+		List<SearchQuery> searchQueries = null;
+		new SearchConfig("default", "v1/order", "1.8.*", searchQueries);
+	}
+	
+	/**
+	 * @verifies fail if given search queries is empty
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldFailIfGivenSearchQueriesIsEmpty() throws Exception {
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("searchQueries must not be empty");
+		List<SearchQuery> searchQueries = Collections.emptyList();
+		new SearchConfig("default", "v1/order", "1.8.*", searchQueries);
+	}
+	
+	/**
+	 * @verifies create an instance of search config
+	 * @see SearchConfig#SearchConfig(String, String, String, SearchQuery)
+	 */
+	@Test
+	public void SearchConfig_shouldCreateAnInstanceOfSearchConfig_ConstructorStringStringStringSearchQuery()
+	        throws Exception {
+		
+		SearchQuery searchQuery = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig = new SearchConfig("default", "v1/order", "1.8.*", searchQuery);
+		
+		assertThat(searchConfig.getId(), is("default"));
+		assertThat(searchConfig.getSupportedResource(), is("v1/order"));
+		assertThat(searchConfig.getSupportedOpenmrsVersions().size(), is(1));
+		assertThat(searchConfig.getSupportedOpenmrsVersions(), hasItem("1.8.*"));
+		assertThat(searchConfig.getSearchQueries().size(), is(1));
+		assertThat(searchConfig.getSearchQueries(), hasItem(searchQuery));
+	}
+	
+	/**
+	 * @verifies create an instance of search config
+	 * @see SearchConfig#SearchConfig(String, String, java.util.Collection, SearchQuery)
+	 */
+	@Test
+	public void SearchConfig_shouldCreateAnInstanceOfSearchConfig_ConstructorString() throws Exception {
+		
+		SearchQuery searchQuery = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig = new SearchConfig("default", "v1/order", asList("1.8.*", "1.9.*"), searchQuery);
+		
+		assertThat(searchConfig.getId(), is("default"));
+		assertThat(searchConfig.getSupportedResource(), is("v1/order"));
+		assertThat(searchConfig.getSupportedOpenmrsVersions().size(), is(2));
+		assertThat(searchConfig.getSupportedOpenmrsVersions(), hasItem("1.8.*"));
+		assertThat(searchConfig.getSupportedOpenmrsVersions(), hasItem("1.9.*"));
+		assertThat(searchConfig.getSearchQueries().size(), is(1));
+		assertThat(searchConfig.getSearchQueries(), hasItem(searchQuery));
+	}
+	
+	/**
+	 * @verifies create an instance of search config
+	 * @see SearchConfig#SearchConfig(String, String, String, java.util.Collection)
+	 */
+	@Test
+	public void SearchConfig_shouldCreateAnInstanceOfSearchConfig_ConstructorStringStringStringCollection() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by encounter").withRequiredParameters(
+		    "encounter").build();
+		SearchConfig searchConfig = new SearchConfig("default", "v1/order", "1.8.*", Arrays.asList(searchQuery1,
+		    searchQuery2));
+		
+		assertThat(searchConfig.getId(), is("default"));
+		assertThat(searchConfig.getSupportedResource(), is("v1/order"));
+		assertThat(searchConfig.getSupportedOpenmrsVersions().size(), is(1));
+		assertThat(searchConfig.getSupportedOpenmrsVersions(), hasItem("1.8.*"));
+		assertThat(searchConfig.getSearchQueries().size(), is(2));
+		assertThat(searchConfig.getSearchQueries(), hasItem(searchQuery1));
+		assertThat(searchConfig.getSearchQueries(), hasItem(searchQuery2));
+	}
+	
+	/**
+	 * @verifies return same hashcode for equal search configs
+	 * @see SearchConfig#hashCode()
+	 */
+	@Test
+	public void hashCode_shouldReturnSameHashcodeForEqualSearchConfigs() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig2 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery2);
+		
+		assertTrue(searchConfig1.equals(searchConfig2));
+		
+		assertThat(searchConfig1.hashCode(), is(searchConfig2.hashCode()));
+	}
+	
+	/**
+	 * @verifies return true if given this
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldReturnTrueIfGivenThis() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		assertTrue(searchConfig1.equals(searchConfig1));
+	}
+	
+	/**
+	 * @verifies return true if this id and supported openmrs version and supported resource are
+	 *           equal to given search configs
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldReturnTrueIfThisIdAndSupportedOpenmrsVersionAndSupportedResourceAreEqualToGivenSearchConfigs()
+	        throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig2 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery2);
+		
+		assertTrue(searchConfig1.equals(searchConfig2));
+	}
+	
+	/**
+	 * @verifies be symmetric
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldBeSymmetric() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig2 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery2);
+		
+		assertTrue(searchConfig1.equals(searchConfig2));
+		assertTrue(searchConfig2.equals(searchConfig1));
+	}
+	
+	/**
+	 * @verifies be transitive
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldBeTransitive() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig2 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery2);
+		
+		SearchQuery searchQuery3 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig3 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery3);
+		
+		assertTrue(searchConfig1.equals(searchConfig2));
+		assertTrue(searchConfig1.equals(searchConfig3));
+		assertTrue(searchConfig2.equals(searchConfig3));
+	}
+	
+	/**
+	 * @verifies return false if given null
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldReturnFalseIfGivenNull() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		assertFalse(searchConfig1.equals(null));
+	}
+	
+	/**
+	 * @verifies return false if given an object which is not an instanceof this class
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldReturnFalseIfGivenAnObjectWhichIsNotAnInstanceofThisClass() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		assertFalse(searchConfig1.equals("String"));
+	}
+	
+	/**
+	 * @verifies return false if this id is not equal to the given search configs id
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldReturnFalseIfThisIdIsNotEqualToTheGivenSearchConfigsId() throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig2 = new SearchConfig("other", "v1/order", "1.8.*", searchQuery2);
+		
+		assertFalse(searchConfig1.equals(searchConfig2));
+	}
+	
+	/**
+	 * @verifies return false if this supported openmrs version is not equal to given search configs
+	 *           supported openmrs version
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldReturnFalseIfThisSupportedOpenmrsVersionIsNotEqualToGivenSearchConfigsSupportedOpenmrsVersion()
+	        throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig2 = new SearchConfig("default", "v1/order", "1.9.*", searchQuery2);
+		
+		assertFalse(searchConfig1.equals(searchConfig2));
+	}
+	
+	/**
+	 * @verifies return false if this supported resource is not equal to given search configs
+	 *           supported resource
+	 * @see SearchConfig#equals(Object)
+	 */
+	@Test
+	public void equals_shouldReturnFalseIfThisSupportedResourceIsNotEqualToGivenSearchConfigsSupportedResource()
+	        throws Exception {
+		
+		SearchQuery searchQuery1 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig1 = new SearchConfig("default", "v1/order", "1.8.*", searchQuery1);
+		
+		SearchQuery searchQuery2 = new SearchQuery.Builder("Enables to search by patient").withRequiredParameters("patient")
+		        .build();
+		SearchConfig searchConfig2 = new SearchConfig("default", "v2/order", "1.8.*", searchQuery2);
+		
+		assertFalse(searchConfig1.equals(searchConfig2));
+	}
+}


### PR DESCRIPTION
* add javadocs to SearchConfig
* add test class for SearchConfig
* move validation of parameters in constructor before setting the instance
properties. so we fail fast if a param is invalid (also fixes a NPE if given a
null supportedOpenmrsVersions).
* simplify SearchConfig.equals()
id, supportedResource, supportedOpenmrsVersion do not have to be tested for
null since they cannot be null (see constructors).
replace obj == null and obj.getClass() != getClass() with instanceof operator

see https://issues.openmrs.org/browse/RESTWS-619