### PR TITLE
RESTWS-623 Make RestServiceImpl.getResourceByName testable

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
@@ -59,12 +59,22 @@ public class RestServiceImpl implements RestService {
 	
 	private RestHelperService restHelperService;
 	
+	private OpenmrsClassScanner openmrsClassScanner;
+	
 	public RestHelperService getRestHelperService() {
 		return restHelperService;
 	}
 	
 	public void setRestHelperService(RestHelperService restHelperService) {
 		this.restHelperService = restHelperService;
+	}
+	
+	public OpenmrsClassScanner getOpenmrsClassScanner() {
+		return openmrsClassScanner;
+	}
+	
+	public void setOpenmrsClassScanner(OpenmrsClassScanner openmrsClassScanner) {
+		this.openmrsClassScanner = openmrsClassScanner;
 	}
 	
 	public RestServiceImpl() {
@@ -186,7 +196,7 @@ public class RestServiceImpl implements RestService {
 		
 		List<Class<? extends Resource>> resources;
 		try {
-			resources = OpenmrsClassScanner.getInstance().getClasses(Resource.class, true);
+			resources = openmrsClassScanner.getClasses(Resource.class, true);
 		}
 		catch (IOException e) {
 			throw new APIException("Cannot access REST resources", e);
@@ -391,6 +401,19 @@ public class RestServiceImpl implements RestService {
 		return new NamedRepresentation(requested);
 	}
 	
+	/**
+	 * @see org.openmrs.module.webservices.rest.web.api.RestService#getResourceByName(String)
+	 * @should return resource for given name
+	 * @should return resource for given name and ignore unannotated resources
+	 * @should fail if failed to get resource classes
+	 * @should fail if resource for given name cannot be found
+	 * @should fail if resource for given name does not support the current openmrs version
+	 * @should return subresource for given name
+	 * @should fail if subresource for given name does not support the current openmrs version
+	 * @should fail if two resources with same name and order are found for given name
+	 * @should return resource with lower order value if two resources with the same name are found
+	 *         for given name
+	 */
 	@Override
 	public Resource getResourceByName(String name) throws APIException {
 		initializeResources();

--- a/omod-common/src/main/resources/webModuleApplicationContext.xml
+++ b/omod-common/src/main/resources/webModuleApplicationContext.xml
@@ -10,6 +10,11 @@
   		    http://www.springframework.org/schema/context
   		    http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
+	<bean id="openmrsClassScanner"
+		  class="org.openmrs.module.webservices.rest.web.OpenmrsClassScanner"
+		factory-method="getInstance" >
+	</bean>
+
 	<bean id="restService"
 		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager">
@@ -19,6 +24,7 @@
 			<bean
 				class="org.openmrs.module.webservices.rest.web.api.impl.RestServiceImpl">
 				<property name="restHelperService" ref="restHelperService"></property>
+				<property name="openmrsClassScanner" ref="openmrsClassScanner"></property>
 			</bean>
 		</property>
 		<property name="preInterceptors">

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAndOrderMockingBirdFantasyResource.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAndOrderMockingBirdFantasyResource.java
@@ -1,0 +1,28 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.mockingbird.test.rest.resource;
+
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.Resource;
+
+/**
+ * Fake {@code Resource} used in tests at
+ * {@link org.openmrs.module.webservices.rest.web.api.impl.RestServiceImplTest}. Located in a fake
+ * package not under org.openmrs.xxx on purpose otherwise it will be picked up by other tests due to
+ * {@link org.openmrs.module.webservices.rest.web.OpenmrsClassScanner} and its classpath pattern.
+ */
+@org.openmrs.module.webservices.rest.web.annotation.Resource(name = RestConstants.VERSION_1 + "/mockingbirdfantasy", order = 1, supportedClass = String.class, supportedOpenmrsVersions = { "1.9.*" })
+public class DuplicateNameAndOrderMockingBirdFantasyResource implements Resource {
+	
+	@Override
+	public String getUri(Object instance) {
+		return "v1/mockingbirdfantasy";
+	}
+}

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameMockingBirdFantasyResource.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameMockingBirdFantasyResource.java
@@ -1,0 +1,28 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.mockingbird.test.rest.resource;
+
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.Resource;
+
+/**
+ * Fake {@code Resource} used in tests at
+ * {@link org.openmrs.module.webservices.rest.web.api.impl.RestServiceImplTest}. Located in a fake
+ * package not under org.openmrs.xxx on purpose otherwise it will be picked up by other tests due to
+ * {@link org.openmrs.module.webservices.rest.web.OpenmrsClassScanner} and its classpath pattern.
+ */
+@org.openmrs.module.webservices.rest.web.annotation.Resource(name = RestConstants.VERSION_1 + "/mockingbirdfantasy", order = 2, supportedClass = String.class, supportedOpenmrsVersions = { "1.9.*" })
+public class DuplicateNameMockingBirdFantasyResource implements Resource {
+	
+	@Override
+	public String getUri(Object instance) {
+		return "v1/mockingbirdfantasy";
+	}
+}

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/MockingBirdFantasyNameResource.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/MockingBirdFantasyNameResource.java
@@ -1,0 +1,27 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.mockingbird.test.rest.resource;
+
+import org.openmrs.module.webservices.rest.web.resource.api.Resource;
+
+/**
+ * Fake {@code Resource} used in tests at
+ * {@link org.openmrs.module.webservices.rest.web.api.impl.RestServiceImplTest}. Located in a fake
+ * package not under org.openmrs.xxx on purpose otherwise it will be picked up by other tests due to
+ * {@link org.openmrs.module.webservices.rest.web.OpenmrsClassScanner} and its classpath pattern.
+ */
+@org.openmrs.module.webservices.rest.web.annotation.SubResource(parent = MockingBirdFantasyResource.class, supportedClass = String.class, path = "name", supportedOpenmrsVersions = { "1.9.*" })
+public class MockingBirdFantasyNameResource implements Resource {
+	
+	@Override
+	public String getUri(Object instance) {
+		return "name";
+	}
+}

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/MockingBirdFantasyResource.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/MockingBirdFantasyResource.java
@@ -1,0 +1,28 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.mockingbird.test.rest.resource;
+
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.Resource;
+
+/**
+ * Fake {@code Resource} used in tests at
+ * {@link org.openmrs.module.webservices.rest.web.api.impl.RestServiceImplTest}. Located in a fake
+ * package not under org.openmrs.xxx on purpose otherwise it will be picked up by other tests due to
+ * {@link org.openmrs.module.webservices.rest.web.OpenmrsClassScanner} and its classpath pattern.
+ */
+@org.openmrs.module.webservices.rest.web.annotation.Resource(name = RestConstants.VERSION_1 + "/mockingbirdfantasy", order = 1, supportedClass = String.class, supportedOpenmrsVersions = { "1.9.*" })
+public class MockingBirdFantasyResource implements Resource {
+	
+	@Override
+	public String getUri(Object instance) {
+		return "v1/mockingbirdfantasy";
+	}
+}

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/UnannotatedMockingBirdFantasyResource.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/UnannotatedMockingBirdFantasyResource.java
@@ -1,0 +1,27 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.mockingbird.test.rest.resource;
+
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.Resource;
+
+/**
+ * Fake {@code Resource} used in tests at
+ * {@link org.openmrs.module.webservices.rest.web.api.impl.RestServiceImplTest}. Located in a fake
+ * package not under org.openmrs.xxx on purpose otherwise it will be picked up by other tests due to
+ * {@link org.openmrs.module.webservices.rest.web.OpenmrsClassScanner} and its classpath pattern.
+ */
+public class UnannotatedMockingBirdFantasyResource implements Resource {
+	
+	@Override
+	public String getUri(Object instance) {
+		return "v1/mockingbirdfantasy";
+	}
+}


### PR DESCRIPTION
* add dependency for OpenmrsClassScanner to RestServiceImpl and inject via xml
using the factory method on OpenmrsClassScanner.getInstance() which returns the
singleton instance
* add first tests for getResourceByName by mocking the
OpenmrsClassScanner.getClasses

see https://issues.openmrs.org/browse/RESTWS-623