### PR TITLE
Add tests to RestServiceImpl.getSearchHandlers

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/RestService.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/RestService.java
@@ -81,6 +81,10 @@ public interface RestService {
 	 */
 	public void initialize();
 	
+	/**
+	 * Returns all search handlers.
+	 * 
+	 * @return all search handlers or <code>null</code> if none registered
+	 */
 	public List<SearchHandler> getAllSearchHandlers();
-	
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
@@ -632,16 +632,23 @@ public class RestServiceImpl implements RestService {
 		return resourceHandlers;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.openmrs.module.webservices.rest.web.api.RestService#getSearchHandlers(java.lang.String)
+	/**
+	 * @see org.openmrs.module.webservices.rest.web.api.RestService#getAllSearchHandlers()
+	 * @should return all search handlers if search handlers have been initialized
+	 * @should return null if search handlers have not been initialized
 	 */
 	public List<SearchHandler> getAllSearchHandlers() {
 		
 		return allSearchHandlers;
 	}
 	
-	/* (non-Javadoc)
+	/**
 	 * @see org.openmrs.module.webservices.rest.web.api.RestService#getSearchHandlers(java.lang.String)
+	 * @should return search handlers for given resource name
+	 * @should return null if no search handler is found for given resource name
+	 * @should return null if no search handler is found for current openmrs version
+	 * @should return null given null
+	 * @should fail if two search handlers for the same resource have the same id
 	 */
 	@Override
 	public Set<SearchHandler> getSearchHandlers(String resourceName) {


### PR DESCRIPTION
and getAllSearchHandlers

* add tests to RestServiceImpl.getSearchHandlers
* add tests to RestServiceImpl.getAllSearchHandlers
* adjust test of RestServiceImpl.getSearchHandler to match style used in
all other tests
* fix javadocs for getAllSearchHandlers in RestServiceImpl and RestService