### PR TITLE
Add tests for RestServiceImpl.initialize()

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
@@ -663,6 +663,15 @@ public class RestServiceImpl implements RestService {
 		return searchHandlersByResource.get(resourceName);
 	}
 	
+	/**
+	 * @see RestService#initialize()
+	 * @should initialize resources and search handlers
+	 * @should clear cached resources and search handlers and reinitialize them
+	 * @should fail if failed to get resource classes
+	 * @should fail if failed to instantiate a resource
+	 * @should fail if two resources with same name and order are found
+	 * @should fail if two search handlers for the same resource have the same id
+	 */
 	@Override
 	public void initialize() {
 		

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/InstantiateExceptionAnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/InstantiateExceptionAnimalResource_1_9.java
@@ -1,0 +1,90 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.mockingbird.test.rest.resource;
+
+import org.mockingbird.test.Animal;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+/**
+ * Fake {@code Resource} used in tests at
+ * {@link org.openmrs.module.webservices.rest.web.api.impl.RestServiceImplTest}. Located in a fake
+ * package not under org.openmrs.xxx on purpose otherwise it will be picked up by other tests due to
+ * {@link org.openmrs.module.webservices.rest.web.OpenmrsClassScanner} and its classpath pattern.
+ */
+@org.openmrs.module.webservices.rest.web.annotation.Resource(name = RestConstants.VERSION_1 + "/animal", order = 1, supportedClass = Animal.class, supportedOpenmrsVersions = { "1.9.*" })
+public class InstantiateExceptionAnimalResource_1_9 extends DelegatingCrudResource<Animal> {
+	
+	public InstantiateExceptionAnimalResource_1_9() {
+		throw new RuntimeException("Used to test RestServiceImpl");
+	}
+	
+	/**
+	 * @see DelegatingResourceHandler#getResourceVersion()
+	 */
+	@Override
+	public String getResourceVersion() {
+		return "1.9";
+	}
+	
+	/**
+	 * @see DelegatingResourceHandler#newDelegate()
+	 */
+	@Override
+	public Animal newDelegate() {
+		return new Animal();
+	}
+	
+	/**
+	 * @see DelegatingResourceHandler#save(Object)
+	 */
+	@Override
+	public Animal save(Animal delegate) {
+		return null;
+	}
+	
+	/**
+	 * @see DelegatingResourceHandler#getRepresentationDescription(Representation)
+	 */
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		return null;
+	}
+	
+	/**
+	 * @see DelegatingCrudResource#getByUniqueId(String)
+	 */
+	@Override
+	public Animal getByUniqueId(String uniqueId) {
+		return null;
+	}
+	
+	/**
+	 * @see DelegatingCrudResource#delete(Object, String, RequestContext)
+	 */
+	@Override
+	protected void delete(Animal delegate, String reason, RequestContext context) throws ResponseException {
+		throw new ResourceDoesNotSupportOperationException();
+	}
+	
+	/**
+	 * @see DelegatingCrudResource#purge(Object, RequestContext)
+	 */
+	@Override
+	public void purge(Animal delegate, RequestContext context) throws ResponseException {
+		throw new ResourceDoesNotSupportOperationException();
+	}
+}


### PR DESCRIPTION
* add a new fake Resource to be able to test
failure of instantiating a new Resource when initializing the
resource cache via initialize()

establishing tests first so it will be safe to work on issue https://issues.openmrs.org/browse/RESTWS-612