### PR TITLE
RESTWS-636 - groupMembers in obs groupMembers fix

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ObsComplexValueController1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ObsComplexValueController1_8.java
@@ -35,10 +35,10 @@ import java.io.InputStream;
 @Controller
 @RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/obs")
 public class ObsComplexValueController1_8 extends BaseRestController {
-
+	
 	@Autowired
 	ObsService obsService;
-
+	
 	@RequestMapping(value = "/{uuid}/value", method = RequestMethod.GET)
 	public void getFile(@PathVariable("uuid") String uuid, HttpServletResponse response) throws Exception {
 		Obs obs = obsService.getObsByUuid(uuid);
@@ -47,14 +47,15 @@ public class ObsComplexValueController1_8 extends BaseRestController {
 		}
 		obs = obsService.getComplexObs(obs.getId(), "RAW_VIEW");
 		ComplexData complexData = obs.getComplexData();
-
+		
 		String mimeType;
 		try {
 			mimeType = BeanUtils.getProperty(complexData, "mimeType");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			mimeType = "application/force-download"; //no mimeType for openmrs-api 1.11 and below
 		}
-
+		
 		response.setContentType(mimeType);
 		if (StringUtils.isNotBlank(complexData.getTitle())) {
 			response.setHeader("Content-Disposition", "attachment; filename=" + complexData.getTitle());
@@ -74,7 +75,7 @@ public class ObsComplexValueController1_8 extends BaseRestController {
 			}
 			ImageIO.write(image, type, response.getOutputStream());
 		}
-
+		
 		response.flushBuffer();
 	}
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -9,26 +9,14 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Concept;
-import org.openmrs.ConceptComplex;
 import org.openmrs.ConceptNumeric;
+import org.openmrs.Drug;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
-import org.openmrs.Drug;
 import org.openmrs.api.APIException;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.ObsService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -53,10 +41,17 @@ import org.openmrs.module.webservices.rest.web.response.IllegalRequestException;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.obs.ComplexData;
-import org.openmrs.obs.ComplexObsHandler;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.xml.bind.DatatypeConverter;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 /**
  * {@link Resource} for Obs, supporting standard CRUD operations
@@ -199,7 +194,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	public String getDisplayString(Obs obs) {
 		if (obs.getConcept() == null)
 			return "";
-
+		
 		return obs.getConcept().getName() + ": " + obs.getValueAsString(Context.getLocale());
 	}
 	
@@ -221,7 +216,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 			so.put("links", links);
 			return so;
 		}
-
+		
 		if (obs.isObsGrouping())
 			return null;
 		
@@ -272,7 +267,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	public static void setGroupMembers(Obs obsGroup, Set<Obs> members) {
 		for (Obs member : members) {
 			member.setObsGroup(obsGroup);
-			member.setGroupMembers(Collections.<Obs> emptySet());
+			//member.setGroupMembers(Collections.<Obs> emptySet());
 		}
 		obsGroup.setGroupMembers(members);
 	}
@@ -322,7 +317,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		if (value != null) {
 			if (obs.isComplex()) {
 				byte[] bytes = DatatypeConverter.parseBase64Binary(value.toString());
-
+				
 				ComplexData complexData = new ComplexData(obs.getUuid() + ".raw", new ByteArrayInputStream(bytes));
 				obs.setComplexData(complexData);
 			} else if (obs.getConcept().getDatatype().isCoded()) {
@@ -425,30 +420,30 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		
 		return new NeedsPaging<Obs>(Context.getObsService().getObservations(context.getParameter("q")), context);
 	}
-
+	
 	@Override
 	public Object upload(MultipartFile file, RequestContext context) throws ResponseException, IOException {
 		String json = context.getParameter("json");
 		if (json == null) {
 			throw new IllegalRequestException("Obs metadata must be included in a request parameter named 'json'.");
 		}
-
+		
 		SimpleObject object = SimpleObject.parseJson(json);
 		Obs obs = convert(object);
-
+		
 		if (!obs.isComplex()) {
 			throw new IllegalRequestException("Complex concept must be set in order to create a complex obs with data.");
 		}
-
+		
 		ObsService obsService = Context.getObsService();
-
+		
 		ComplexData complexData = new ComplexData(file.getName(), new ByteArrayInputStream(file.getBytes()));
 		obs.setComplexData(complexData);
-
+		
 		obs = obsService.saveObs(obs, null);
-
+		
 		SimpleObject ret = (SimpleObject) ConversionUtil.convertToRepresentation(obs, Representation.DEFAULT);
 		return ret;
 	}
-
+	
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -267,7 +267,6 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	public static void setGroupMembers(Obs obsGroup, Set<Obs> members) {
 		for (Obs member : members) {
 			member.setObsGroup(obsGroup);
-			//member.setGroupMembers(Collections.<Obs> emptySet());
 		}
 		obsGroup.setGroupMembers(members);
 	}

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
@@ -141,6 +141,66 @@ public class EncounterController1_9Test extends MainResourceControllerTest {
 	}
 	
 	@Test
+	public void createEncounter_shouldCreateEncounterWithNestedObs() throws Exception {
+		long before = getAllCount();
+		
+		List<SimpleObject> obs = new ArrayList<SimpleObject>();
+		List<SimpleObject> parentGroupMembers = new ArrayList<SimpleObject>();
+		List<SimpleObject> child1GroupMembers = new ArrayList<SimpleObject>();
+		
+		SimpleObject child1child1 = new SimpleObject();
+		child1child1.put("value", 1);
+		child1child1.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
+		child1GroupMembers.add(child1child1);
+		
+		SimpleObject child1child2 = new SimpleObject();
+		child1child2.put("value", 2);
+		child1child2.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
+		child1GroupMembers.add(child1child2);
+		
+		SimpleObject child1 = new SimpleObject();
+		child1.put("groupMembers", child1GroupMembers);
+		parentGroupMembers.add(child1);
+		
+		SimpleObject child2 = new SimpleObject();
+		child2.put("value", 3);
+		child2.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
+		parentGroupMembers.add(child2);
+		
+		SimpleObject child3 = new SimpleObject();
+		child3.put("value", 4);
+		child3.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
+		parentGroupMembers.add(child3);
+		
+		SimpleObject parent = new SimpleObject();
+		parent.put("groupMembers", parentGroupMembers);
+		obs.add(parent);
+		
+		SimpleObject encounter = new SimpleObject();
+		encounter.put("location", "9356400c-a5a2-4532-8f2b-2361b3446eb8");
+		encounter.put("encounterType", "61ae96f4-6afe-4351-b6f8-cd4fc383cce1");
+		encounter.put("encounterDatetime", "2011-01-15");
+		encounter.put("patient", "da7f524f-27ce-4bb2-86d6-6d1d05312bd5");
+		encounter.put("provider", "ba1b19c2-3ed6-4f63-b8c0-f762dc8d7562");
+		encounter.put("obs", obs);
+		
+		MockHttpServletResponse response = handle(newPostRequest(getURI(), encounter));
+		SimpleObject newEncounter = deserialize(response);
+		
+		Assert.assertNotNull(newEncounter);
+		Assert.assertEquals(before + 1, getAllCount());
+		
+		List<Map<String, String>> result = (List<Map<String, String>>) newEncounter.get("obs");
+		
+		Assert.assertEquals(1, result.size());
+		Set<String> obsDisplayValues = new HashSet<String>();
+		for (Map<String, String> o : result) {
+			obsDisplayValues.add(o.get("display"));
+		}
+		Assert.assertTrue(obsDisplayValues.contains("WEIGHT (KG): 1,2,3,4"));
+	}
+	
+	@Test
 	public void createEncounter_shouldCreateANewEncounterWithObs() throws Exception {
 		long before = getAllCount();
 		Util.log("before = ", before);

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterProvider;
+import org.openmrs.Obs;
 import org.openmrs.Visit;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.VisitService;
@@ -36,11 +37,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Calendar;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Contains tests for the 19 ext {@link EncounterController} Overrides the failing test methods from
@@ -142,62 +147,55 @@ public class EncounterController1_9Test extends MainResourceControllerTest {
 	
 	@Test
 	public void createEncounter_shouldCreateEncounterWithNestedObs() throws Exception {
-		long before = getAllCount();
+		List<SimpleObject> obsObject = new ArrayList<SimpleObject>();
+		List<SimpleObject> parentGroupMembersObject = new ArrayList<SimpleObject>();
+		List<SimpleObject> child1GroupMembersObject = new ArrayList<SimpleObject>();
 		
-		List<SimpleObject> obs = new ArrayList<SimpleObject>();
-		List<SimpleObject> parentGroupMembers = new ArrayList<SimpleObject>();
-		List<SimpleObject> child1GroupMembers = new ArrayList<SimpleObject>();
+		SimpleObject grandchild = new SimpleObject();
+		grandchild.put("value", 1);
+		grandchild.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
+		child1GroupMembersObject.add(grandchild);
 		
-		SimpleObject child1child1 = new SimpleObject();
-		child1child1.put("value", 1);
-		child1child1.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
-		child1GroupMembers.add(child1child1);
-		
-		SimpleObject child1child2 = new SimpleObject();
-		child1child2.put("value", 2);
-		child1child2.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
-		child1GroupMembers.add(child1child2);
-		
-		SimpleObject child1 = new SimpleObject();
-		child1.put("groupMembers", child1GroupMembers);
-		parentGroupMembers.add(child1);
-		
-		SimpleObject child2 = new SimpleObject();
-		child2.put("value", 3);
-		child2.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
-		parentGroupMembers.add(child2);
-		
-		SimpleObject child3 = new SimpleObject();
-		child3.put("value", 4);
-		child3.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
-		parentGroupMembers.add(child3);
+		SimpleObject child = new SimpleObject();
+		child.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
+		child.put("groupMembers", child1GroupMembersObject);
+		parentGroupMembersObject.add(child);
 		
 		SimpleObject parent = new SimpleObject();
-		parent.put("groupMembers", parentGroupMembers);
-		obs.add(parent);
+		parent.put("concept", "c607c80f-1ea9-4da3-bb88-6276ce8868dd");
+		parent.put("groupMembers", parentGroupMembersObject);
+		obsObject.add(parent);
 		
 		SimpleObject encounter = new SimpleObject();
 		encounter.put("location", "9356400c-a5a2-4532-8f2b-2361b3446eb8");
 		encounter.put("encounterType", "61ae96f4-6afe-4351-b6f8-cd4fc383cce1");
 		encounter.put("encounterDatetime", "2011-01-15");
 		encounter.put("patient", "da7f524f-27ce-4bb2-86d6-6d1d05312bd5");
-		encounter.put("provider", "ba1b19c2-3ed6-4f63-b8c0-f762dc8d7562");
-		encounter.put("obs", obs);
+		encounter.put("obs", obsObject);
 		
 		MockHttpServletResponse response = handle(newPostRequest(getURI(), encounter));
-		SimpleObject newEncounter = deserialize(response);
-		
-		Assert.assertNotNull(newEncounter);
-		Assert.assertEquals(before + 1, getAllCount());
-		
-		List<Map<String, String>> result = (List<Map<String, String>>) newEncounter.get("obs");
-		
-		Assert.assertEquals(1, result.size());
-		Set<String> obsDisplayValues = new HashSet<String>();
-		for (Map<String, String> o : result) {
-			obsDisplayValues.add(o.get("display"));
-		}
-		Assert.assertTrue(obsDisplayValues.contains("WEIGHT (KG): 1,2,3,4"));
+		String newEncounterUuid = deserialize(response).get("uuid").toString();
+
+		Encounter newEncounter = Context.getEncounterService().getEncounterByUuid(newEncounterUuid);
+		Set<Obs> encounterObs = newEncounter.getAllObs();
+		Assert.assertThat(encounterObs.size(), is(1));
+
+		Obs parentObs = encounterObs.iterator().next();
+		Assert.assertTrue(parentObs.hasGroupMembers());
+
+		Set<Obs> parentGroupMembers = parentObs.getGroupMembers();
+		Assert.assertThat(parentGroupMembers.size(), is(1));
+
+		Obs childObs = parentGroupMembers.iterator().next();
+		Assert.assertTrue(childObs.hasGroupMembers());
+
+		Set<Obs> childGroupMembers = childObs.getGroupMembers();
+		Assert.assertThat(childGroupMembers.size(), is(1));
+
+		Obs grandchildObs = childGroupMembers.iterator().next();
+		Assert.assertThat(grandchildObs.getValueNumeric(), is(1.0));
+
+		System.out.println("");
 	}
 	
 	@Test

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsController1_9Test.java
@@ -37,13 +37,13 @@ import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.*;
 
 public class ObsController1_9Test extends MainResourceControllerTest {
-
+	
 	@Autowired
 	ConceptService conceptService;
-
+	
 	@Autowired
 	AdministrationService adminService;
-
+	
 	@Test
 	public void getObs_shouldGetObsConceptByConceptMappings() throws Exception {
 		String json = "{ \"value\":\"" + 10.0 + "\", \"person\":\"" + RestTestConstants1_8.PERSON_UUID
@@ -115,55 +115,56 @@ public class ObsController1_9Test extends MainResourceControllerTest {
 		Assert.assertEquals(yesConceptUuid, PropertyUtils.getProperty(yesValue, "uuid"));
 		Assert.assertEquals(noConceptUuid, PropertyUtils.getProperty(noValue, "uuid"));
 	}
-
+	
 	@Test
 	public void shouldPostValueInJsonAndFetchComplexObs() throws Exception {
 		ConceptComplex conceptComplex = newConceptComplex();
-
+		
 		InputStream in = getClass().getClassLoader().getResourceAsStream("customTestDataset.xml");
-
+		
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		IOUtils.copy(in, out);
-
+		
 		String value = DatatypeConverter.printBase64Binary(out.toByteArray());
-
+		
 		String json = "{\"concept\":\"" + conceptComplex.getUuid() + "\"," + "\"value\":\"" + value
-				+ "\",\"person\":\"5946f880-b197-400b-9caa-a3c661d23041\","
-				+ "\"obsDatetime\":\"2015-09-07T00:00:00.000+0530\"}";
-
+		        + "\",\"person\":\"5946f880-b197-400b-9caa-a3c661d23041\","
+		        + "\"obsDatetime\":\"2015-09-07T00:00:00.000+0530\"}";
+		
 		SimpleObject response = deserialize(handle(newPostRequest(getURI(), json)));
-
+		
 		MockHttpServletResponse rawResponse = handle(newGetRequest(getURI() + "/" + response.get("uuid") + "/value"));
-
+		
 		assertThat(out.toByteArray(), is(equalTo(rawResponse.getContentAsByteArray())));
 	}
-
+	
 	@Test
 	public void shouldUploadFileAndFetchComplexObs() throws Exception {
 		ConceptComplex conceptComplex = newConceptComplex();
-
+		
 		InputStream in = getClass().getClassLoader().getResourceAsStream("customTestDataset.xml");
-
+		
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		IOUtils.copy(in, out);
-
-		String json = "{\"concept\":\"" + conceptComplex.getUuid() + "\", \"person\":\"5946f880-b197-400b-9caa-a3c661d23041\","
-				+ "\"obsDatetime\":\"2015-09-07T00:00:00.000+0530\"}";
-
+		
+		String json = "{\"concept\":\"" + conceptComplex.getUuid()
+		        + "\", \"person\":\"5946f880-b197-400b-9caa-a3c661d23041\","
+		        + "\"obsDatetime\":\"2015-09-07T00:00:00.000+0530\"}";
+		
 		MockMultipartHttpServletRequest request = newUploadRequest(getURI());
 		request.addFile(new MockMultipartFile("file", "customTestDataset.xml", null, out.toByteArray()));
 		request.addParameter("json", json);
-
+		
 		SimpleObject response = deserialize(handle(request));
-
+		
 		MockHttpServletResponse rawResponse = handle(newGetRequest(getURI() + "/" + response.get("uuid") + "/value"));
-
+		
 		assertThat(out.toByteArray(), is(equalTo(rawResponse.getContentAsByteArray())));
 	}
-
+	
 	private ConceptComplex newConceptComplex() {
 		setupBinaryDataHandler();
-
+		
 		ConceptComplex conceptComplex = new ConceptComplex();
 		conceptComplex.setHandler("BinaryDataHandler");
 		conceptComplex.addName(new ConceptName("Xml Test Data", Locale.ENGLISH));
@@ -172,7 +173,7 @@ public class ObsController1_9Test extends MainResourceControllerTest {
 		conceptService.saveConcept(conceptComplex);
 		return conceptComplex;
 	}
-
+	
 	private void setupBinaryDataHandler() {
 		adminService.saveGlobalProperty(new GlobalProperty("obs.complex_obs_dir", "complexObsDir"));
 	}

--- a/omod-1.9/src/test/resources/customConceptDataset1_9.xml
+++ b/omod-1.9/src/test/resources/customConceptDataset1_9.xml
@@ -16,4 +16,16 @@
 	<concept_map_type concept_map_type_id="2" name="same-as" description="Indicates similarity" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="35543629-7d8c-11e1-909d-c80aa9edcf4e"/>
 	<concept_reference_map concept_map_id="1" concept_id="5089" concept_reference_term_id="1" concept_map_type_id="2" creator="1" date_created="2004-08-12 00:00:00.0" uuid="23b6e712-49d8-11e0-8fed-18a905e044dc"/>
 	<concept_reference_map concept_map_id="2" concept_id="5497" concept_reference_term_id="2" concept_map_type_id="2" creator="1" date_created="2004-08-12 00:00:00.0" uuid="2cc480ee-49d8-11e0-8fed-18a905e044dc"/>
+
+	<concept concept_id="5090" retired="false" datatype_id="1" class_id="1" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="c607c80f-1ea9-4da3-bb88-6276ce8868ee"/>
+	<concept concept_id="5091" retired="false" datatype_id="1" class_id="1" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="c607c80f-1ea9-4da3-bb88-6276ce8868ff"/>
+	<concept concept_id="5092" retired="false" datatype_id="1" class_id="1" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="c607c80f-1ea9-4da3-bb88-6276ce8868gg"/>
+	<concept concept_id="5093" retired="false" datatype_id="1" class_id="1" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="c607c80f-1ea9-4da3-bb88-6276ce8868hh"/>
+	<concept concept_id="5094" retired="false" datatype_id="1" class_id="1" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="c607c80f-1ea9-4da3-bb88-6276ce8868ii"/>
+
+	<concept_name concept_id="5090" name="Child 1" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="1439" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="9bc5693a-f558-40c9-8177-145a4b119cb8"/>
+	<concept_name concept_id="5091" name="Child 1 Child 1" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="1439" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="9bc5693a-f558-40c9-8177-145a4b119cc9"/>
+	<concept_name concept_id="5092" name="Child 1 Child 2" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="1439" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="9bc5693a-f558-40c9-8177-145a4b119cd0"/>
+	<concept_name concept_id="5093" name="Child 2" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="1439" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="9bc5693a-f558-40c9-8177-145a4b119ce1"/>
+	<concept_name concept_id="5094" name="Child 3" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="1439" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="9bc5693a-f558-40c9-8177-145a4b119cf2"/>
 </dataset>

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/EncounterController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/EncounterController2_0Test.java
@@ -33,12 +33,12 @@ import static org.junit.Assert.assertEquals;
 public class EncounterController2_0Test extends MainResourceControllerTest {
 	
 	public static final String currentTimezone = Calendar.getInstance().getTimeZone().getDisplayName(true, TimeZone.SHORT);
-
+	
 	@Before
 	public void setup() throws Exception {
 		executeDataSet("EncountersForDifferentTypesWithObservations.xml");
 	}
-
+	
 	@Test
 	public void shouldGetEncountersByEncounterTypeAndPatient() throws Exception {
 		SimpleObject result = deserialize(handle(newGetRequest(getURI(), new Parameter("s", "default"), new Parameter(
@@ -63,17 +63,16 @@ public class EncounterController2_0Test extends MainResourceControllerTest {
 	@Test
 	public void shouldReturnEncounterAsComplexCustomRepresentation() throws Exception {
 		final String customRep = "custom:(uuid,display,patient:(uuid,display),location:(name,tags:(display)))";
-
+		
 		final String encounterUuid = "62967e68-96bb-11e0-8d6b-9b9415a91465";
 		final String encounterDisplay = "sample encounter a 01/08/2008";
 		final String patientUuid = "41c6b35e-c093-11e3-be87-005056821db0";
 		final String patientDisplay = "";
 		final String locationName = "Unknown Location";
-
-		SimpleObject result = deserialize(handle(newGetRequest(getURI(),
-				new Parameter("patient", "41c6b35e-c093-11e3-be87-005056821db0"),
-				new Parameter("v", customRep))));
-
+		
+		SimpleObject result = deserialize(handle(newGetRequest(getURI(), new Parameter("patient",
+		        "41c6b35e-c093-11e3-be87-005056821db0"), new Parameter("v", customRep))));
+		
 		assertEquals(2, Util.getResultsSize(result));
 		List<?> encounters = result.get("results");
 		assertEquals(encounterUuid, PropertyUtils.getProperty(encounters.get(0), "uuid"));

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingCrudResource.java
@@ -85,7 +85,7 @@ public abstract class DelegatingCrudResource<T> extends BaseDelegatingResource<T
 		
 		return ret;
 	}
-
+	
 	public T convert(SimpleObject propertiesToCreate) {
 		DelegatingResourceHandler<? extends T> handler;
 		if (hasTypesDefined()) {
@@ -98,12 +98,12 @@ public abstract class DelegatingCrudResource<T> extends BaseDelegatingResource<T
 		} else {
 			handler = this;
 		}
-
+		
 		T delegate = handler.newDelegate(propertiesToCreate);
 		setConvertedProperties(delegate, propertiesToCreate, handler.getCreatableProperties(), true);
 		return delegate;
 	}
-
+	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.api.Updatable#update(java.lang.String,
 	 *      org.openmrs.module.webservices.rest.SimpleObject)

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/MainResourceControllerTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/MainResourceControllerTest.java
@@ -72,7 +72,7 @@ public abstract class MainResourceControllerTest extends BaseModuleWebContextSen
 		request.addHeader("content-type", "application/json");
 		return request;
 	}
-
+	
 	public MockMultipartHttpServletRequest newUploadRequest(String requestURI) {
 		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
 		request.addHeader("Content-Type", "multipart/form-data");
@@ -285,6 +285,5 @@ public abstract class MainResourceControllerTest extends BaseModuleWebContextSen
 	public String getBaseRestURI() {
 		return "/rest/" + getNamespace() + "/";
 	}
-
-
+	
 }


### PR DESCRIPTION
Test now reproduces issue, so i was able to do some fix attempt.
I've removed line `270` at `ObsResource1_8`, because that was obviously reason why child `groupMembers` was null (every `groupMembers` objects' `groupMembers` were wiped).