### PR TITLE
RESTWS-646 - Optimized fetching all concepts - WIP

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -449,9 +449,29 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#doGetAll(org.openmrs.module.webservices.rest.web.RequestContext)
 	 */
 	@Override
-	protected NeedsPaging<Concept> doGetAll(RequestContext context) {
-		List<Concept> allConcepts = Context.getConceptService().getAllConcepts(null, true, context.getIncludeAll());
-		return new NeedsPaging<Concept>(allConcepts, context);
+	protected AlreadyPaged<Concept> doGetAll(RequestContext context) {
+		
+		List<Locale> locales = new ArrayList<Locale>();
+		locales.add(Context.getLocale());
+		
+		List<ConceptSearchResult> results = Context.getConceptService().getConcepts(null, locales, context.getIncludeAll(),
+		    null, null, null, null, null, context.getStartIndex(), context.getLimit());
+		List<Concept> concepts = new ArrayList<Concept>();
+		for (ConceptSearchResult concept : results) {
+			concepts.add(concept.getConcept());
+		}
+		
+		boolean hasMoreResults = false;
+		
+		if (concepts.size() == context.getLimit()) {
+			Integer count = Context.getConceptService().getCountOfConcepts(null, null, context.getIncludeAll(), null, null,
+			    null, null, null);
+			
+			Integer fetchedCount = context.getStartIndex() + concepts.size();
+			hasMoreResults = (fetchedCount < count);
+		}
+		
+		return new AlreadyPaged<Concept>(context, concepts, hasMoreResults);
 	}
 	
 	/**


### PR DESCRIPTION
This changes improved fetch time of 100 concepts (on localhost server 439 refapp concepts) from 105ms to 90ms (about 10% better peformance).
Notice that this will have even performance impact when querying on database with more concepts.