### PR TITLE
RESTWS-647: Searching for Orderable Concepts

### DIFF
--- a/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/RestTestConstants1_11.java
+++ b/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/RestTestConstants1_11.java
@@ -12,4 +12,6 @@ package org.openmrs.module.webservices.rest.web;
 public class RestTestConstants1_11 {
 	
 	public static final String DRUG_UUID = "05ec820a-d297-44e3-be6e-698531d9dd3f";
+	
+	public static final String ORDERABLE_CONCEPT_UUID = "54fe7338-f82d-11e6-9f88-74dfbf7e4905";
 }


### PR DESCRIPTION
Introduced a new Resource Service that will enable searching for orderable concepts. Orderable concepts can be filtered using the concept class or order type.
