### PR TITLE
RESTWS-650: Correct securityDefinitions Object In OpenAPI Spec

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SecurityScheme.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SecurityScheme.java
@@ -9,18 +9,30 @@
  */
 package org.openmrs.module.webservices.docs.swagger;
 
-public class SecurityDefinitions {
+public class SecurityScheme {
 	
-	private SecurityScheme basic_auth;
+	private String type;
 	
-	public SecurityDefinitions() {
+	private String description;
+	
+	public SecurityScheme(String type, String description) {
+		this.type = type;
+		this.description = description;
 	}
 	
-	public SecurityScheme getBasicAuth() {
-		return basic_auth;
+	public String getType() {
+		return type;
 	}
 	
-	public void setBasicAuth(SecurityScheme basic_auth) {
-		this.basic_auth = basic_auth;
+	public void setType(String type) {
+		this.type = type;
+	}
+	
+	public String getDescription() {
+		return description;
+	}
+	
+	public void setDescription(String description) {
+		this.description = description;
 	}
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SwaggerSpecificationCreator.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SwaggerSpecificationCreator.java
@@ -166,8 +166,9 @@ public class SwaggerSpecificationCreator {
 		info.setVersions(new Versions(OpenmrsConstants.OPENMRS_VERSION, getModuleVersions()));
 		swaggerSpecification.setInfo(info);
 		// security definitions
-		swaggerSpecification.setSecurityDefinitions(new SecurityDefinitions("basic",
-		        "HTTP basic access authentication using OpenMRS username and password"));
+		SecurityDefinitions sd = new SecurityDefinitions();
+		sd.setBasicAuth(new SecurityScheme("basic", "HTTP basic access authentication using OpenMRS username and password"));
+		swaggerSpecification.setSecurityDefinitions(sd);
 		List<String> produces = new ArrayList<String>();
 		produces.add("application/json");
 		produces.add("application/xml");


### PR DESCRIPTION
We were not conforming to the [**`Security Definitions Object`** spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-definitions-object). This PR brings us up to spec by essentially applying the following change:

```diff
{
  swagger: "2.0",
  // stuff that probably isn't relevant
  securityDefinitions: {
+    basicAuth: {
      type: "basic",
      description: "HTTP basic access authentication using OpenMRS username and password"
+    }
  },
  // stuff that probably isn't relevant
}
```

Thanks to @mhawila, @teleivo and @dkayiwa.

<details> 
  <summary><b>References</b></summary>
&nbsp;&nbsp;👉 <a href="https://talk.openmrs.org/t/openmrs-js-swagger-client-issue/10422">Talk thread</a><br/>
&nbsp;&nbsp;👉 <a href="https://github.com/swagger-api/swagger-js/issues/892">GitHub issue</a><br/>
&nbsp;&nbsp;👉 <a href="https://issues.openmrs.org/browse/RESTWS-650">RESTWS-650</a><br/>
</details>