### PR TITLE
RESTWS-561 Document Basic Search

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/OperationEnum.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/OperationEnum.java
@@ -18,11 +18,13 @@ public enum OperationEnum {
 	
 	getWithSearchHandler,
 	
+	getWithDoSearch,
+	
 	postCreate, postSubresource,
 	
 	postUpdate, postUpdateSubresouce,
 	
 	delete, deleteSubresource,
 	
-	purge, purgeSubresource
+	purge, purgeSubresource,
 }


### PR DESCRIPTION
Adds GET operation to root path of a resource, when the resource does not have
a getAll or a custom search handler, but has got doSearch implemented