### PR TITLE
RESTWS-562 Improve Resource Definition Documentation

### DIFF
--- a/OpenMRSFormatter.xml
+++ b/OpenMRSFormatter.xml
@@ -263,5 +263,6 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 </profile>
 </profiles>

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/CareSettingResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/CareSettingResource1_10.java
@@ -13,8 +13,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
 import org.openmrs.CareSetting;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.core.property.EnumProperty;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -65,6 +68,16 @@ public class CareSettingResource1_10 extends MetadataDelegatingCrudResource<Care
 	@Override
 	public DelegatingResourceDescription getCreatableProperties() {
 		throw new ResourceDoesNotSupportOperationException();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("careSettingType", new EnumProperty(CareSetting.CareSettingType.class));
+		}
+		return model;
 	}
 	
 	/**

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10.java
@@ -12,11 +12,17 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 import java.util.Date;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.CareSetting;
 import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -100,6 +106,43 @@ public class OrderResource1_10 extends OrderResource1_8 {
 		} else {
 			return null;
 		}
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("encounter", new StringProperty().example("uuid"))
+		        .property("action", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(Order.Action.class)))
+		        .property("accessionNumber", new StringProperty())
+		        .property("dateActivated", new DateProperty())
+		        .property("scheduledDate", new DateProperty())
+		        .property("patient", new StringProperty().example("uuid"))
+		        .property("concept", new StringProperty().example("uuid"))
+		        .property("careSetting", new StringProperty().example("uuid"))
+		        .property("dateStopped", new DateProperty())
+		        .property("autoExpireDate", new DateProperty())
+		        .property("orderer", new StringProperty().example("uuid"))
+		        .property("previousOrder", new StringProperty().example("uuid"))
+		        .property("urgency", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(Order.Urgency.class)))
+		        .property("orderReason", new StringProperty().example("uuid"))
+		        .property("orderReasonNonCoded", new StringProperty())
+		        .property("instructions", new StringProperty())
+		        .property("commentToFulfiller", new StringProperty())
+		        
+		        .required("orderType").required("patient").required("concept");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("encounter", new RefProperty("#/definitions/EncounterCreate"))
+			        .property("patient", new RefProperty("#/definitions/PatientCreate"))
+			        .property("concept", new RefProperty("#/definitions/ConceptCreate"))
+			        .property("orderer", new RefProperty("#/definitions/UserCreate"))
+			        .property("previousOrder", new RefProperty("#/definitions/OrderCreate"))
+			        .property("orderReason", new RefProperty("#/definitions/ConceptCreate"));
+		}
+		//FIXME missing prop: type
+		return model;
 	}
 	
 	/**

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderTypeResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderTypeResource1_10.java
@@ -13,6 +13,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.OrderType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -145,5 +150,34 @@ public class OrderTypeResource1_10 extends MetadataDelegatingCrudResource<OrderT
 		d.addProperty("parent");
 		d.addProperty("conceptClasses");
 		return d;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("javaClassName", new StringProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("conceptClasses", new ArrayProperty(new RefProperty("#/definitions/ConceptclassGetRef")))
+			        .property("parent", new RefProperty("#/definitions/OrdertypeGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("conceptClasses", new ArrayProperty(new RefProperty("#/definitions/ConceptclassGet")))
+			        .property("parent", new RefProperty("#/definitions/OrdertypeGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("javaClassName", new StringProperty())
+		        .property("parent", new StringProperty().example("uuid")) //FIXME type
+		        .property("conceptClasses", new ArrayProperty(new StringProperty().example("uuid")))
+		        
+		        .required("javaClassName");
 	}
 }

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderableResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderableResource1_10.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+
+import io.swagger.models.Model;
 import org.openmrs.ConceptClass;
 import org.openmrs.ConceptName;
 import org.openmrs.ConceptSearchResult;
@@ -182,6 +184,11 @@ public class OrderableResource1_10 extends BaseDelegatingResource<ConceptSearchR
 		}
 		
 		return description;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return null;
 	}
 	
 	@PropertyGetter("display")

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramEnrollmentResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramEnrollmentResource1_10.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
 import org.openmrs.PatientProgram;
 import org.openmrs.PatientState;
 import org.openmrs.api.context.Context;
@@ -91,6 +97,32 @@ public class ProgramEnrollmentResource1_10 extends ProgramEnrollmentResource1_8 
 		d.addProperty("location");
 		d.addProperty("voided");
 		return d;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("states", new ArrayProperty(new RefProperty("#/definitions/ProgramenrollmentStateCreate")))
+		        .property("outcome", new RefProperty("#/definitions/ConceptCreate"));
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl() //FIXME use super.
+		        .property("dateEnrolled", new DateProperty())
+		        .property("states", new ArrayProperty(new RefProperty("#/definitions/ProgramenrollmentStateCreate")))
+		        .property("outcome", new RefProperty("#/definitions/ConceptCreate"))
+		        .property("location", new RefProperty("#/definitions/LocationCreate"))
+		        .property("voided", new BooleanProperty())
+		        .property("dateCompleted", new DateProperty())
+		        
+		        .required("dateEnrolled");
+		
 	}
 	
 	@Override

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramResource1_10.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Program;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -58,6 +62,17 @@ public class ProgramResource1_10 extends ProgramResource1_8 {
 			return description;
 		}
 		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
+		        .property("outcomesConcept", new StringProperty().example("uuid"));
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("outcomesConcept", new RefProperty("#/definitions/ConceptCreate"));
+		}
+		return model;
 	}
 	
 	@Override

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
@@ -11,6 +11,7 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 
 import java.util.List;
 
+import io.swagger.models.Model;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.CareSetting;
 import org.openmrs.Order;
@@ -121,6 +122,21 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 		        .getResourceBySupportedClass(Order.class);
 		//this actually throws a ResourceDoesNotSupportOperationException
 		return orderResource.getUpdatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return null;
 	}
 	
 	public PageableResult getActiveOrders(Patient patient, RequestContext context) {

--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
@@ -12,6 +12,10 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 import java.util.List;
 
 import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.CareSetting;
 import org.openmrs.Order;
@@ -20,6 +24,7 @@ import org.openmrs.Patient;
 import org.openmrs.TestOrder;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.core.property.EnumProperty;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -125,18 +130,44 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 	}
 	
 	@Override
-	public Model getGETModel(Representation representation) {
-		return null;
+	public Model getGETModel(Representation rep) {
+		OrderResource1_10 orderResource = (OrderResource1_10) Context.getService(RestService.class).getResourceBySupportedClass(Order.class);
+		ModelImpl orderModel = (ModelImpl) orderResource.getGETModel(rep);
+		orderModel
+				.property("laterality", new EnumProperty(TestOrder.Laterality.class))
+				.property("clinicalHistory", new StringProperty())
+				.property("numberOfRepeats", new IntegerProperty());
+
+		if (rep instanceof DefaultRepresentation) {
+			orderModel
+					.property("specimenSource", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("frequency", new RefProperty("#/definitions/OrderfrequencyGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			orderModel
+					.property("specimenSource", new RefProperty("#/definitions/ConceptGet"))
+					.property("frequency", new RefProperty("#/definitions/OrderfrequencyGet"));
+		}
+		return orderModel;
 	}
 	
 	@Override
-	public Model getCREATEModel(Representation representation) {
-		return null;
+	public Model getCREATEModel(Representation rep) {
+		OrderResource1_10 orderResource = (OrderResource1_10) Context.getService(RestService.class)
+				.getResourceBySupportedClass(Order.class);
+		ModelImpl orderModel = (ModelImpl) orderResource.getCREATEModel(rep);
+		return orderModel
+				.property("specimenSource", new StringProperty().example("uuid"))
+				.property("laterality", new EnumProperty(TestOrder.Laterality.class))
+				.property("clinicalHistory", new StringProperty())
+				.property("frequency", new StringProperty().example("uuid"))
+				.property("numberOfRepeats", new IntegerProperty());
 	}
 	
 	@Override
-	public Model getUPDATEModel(Representation representation) {
-		return null;
+	public Model getUPDATEModel(Representation rep) {
+		OrderResource1_10 orderResource = (OrderResource1_10) Context.getService(RestService.class)
+				.getResourceBySupportedClass(Order.class);
+		return orderResource.getUPDATEModel(rep);
 	}
 	
 	public PageableResult getActiveOrders(Patient patient, RequestContext context) {

--- a/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
+++ b/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
@@ -12,6 +12,7 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.models.Model;
 import org.openmrs.Drug;
 import org.openmrs.DrugIngredient;
 import org.openmrs.api.context.Context;
@@ -78,6 +79,21 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return null;
 	}
 	
 	/**

--- a/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
+++ b/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
@@ -13,6 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Drug;
 import org.openmrs.DrugIngredient;
 import org.openmrs.api.context.Context;
@@ -82,18 +86,39 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 	}
 	
 	@Override
-	public Model getGETModel(Representation representation) {
-		return null;
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+					.property("uuid", new StringProperty())
+					.property("display", new StringProperty())
+					.property("strength", new DoubleProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+					.property("ingredient", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("units", new RefProperty("#/definitions/ConceptGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+					.property("ingredient", new RefProperty("#/definitions/ConceptGet"))
+					.property("units", new RefProperty("#/definitions/ConceptGet"));
+		}
+		return modelImpl;
 	}
 	
 	@Override
-	public Model getCREATEModel(Representation representation) {
-		return null;
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+				.property("ingredient", new StringProperty().example("uuid"))
+				.property("strength", new DoubleProperty())
+				.property("units", new StringProperty().example("uuid"))
+
+				.required("ingredient");
 	}
 	
 	@Override
-	public Model getUPDATEModel(Representation representation) {
-		return null;
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/ObsResource1_11.java
+++ b/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/ObsResource1_11.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Obs;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -33,6 +36,20 @@ public class ObsResource1_11 extends ObsResource1_9 {
 			description.addProperty("formFieldNamespace");
 		}
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return ((ModelImpl) super.getGETModel(rep))
+		        .property("formFieldPath", new StringProperty())
+		        .property("formFieldNamespace", new StringProperty());
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("formFieldPath", new StringProperty())
+		        .property("formFieldNamespace", new StringProperty());
 	}
 	
 	/**

--- a/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/PersonResource1_11.java
+++ b/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/PersonResource1_11.java
@@ -9,9 +9,15 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateTimeProperty;
 import org.openmrs.Person;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
@@ -59,6 +65,30 @@ public class PersonResource1_11 extends PersonResource1_8 {
 		description.addProperty("deathdateEstimated");
 		description.addProperty("birthtime");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return addNewProperties(super.getGETModel(rep), rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return addNewProperties(super.getCREATEModel(rep), rep);
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return addNewProperties(super.getUPDATEModel(rep), rep);
+	}
+	
+	private Model addNewProperties(Model model, Representation rep) {
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			((ModelImpl) model)
+			        .property("deathdateEstimated", new BooleanProperty()._default(false))
+			        .property("birthtime", new DateTimeProperty());
+		}
+		return model;
 	}
 	
 	/**

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
@@ -10,6 +10,11 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
 import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.OrderSet;
 import org.openmrs.OrderSetMember;
 import org.openmrs.api.context.Context;
@@ -100,13 +105,41 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 	}
 	
 	@Override
-	public Model getGETModel(Representation representation) {
-		return null;
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+					.property("uuid", new StringProperty())
+					.property("display", new StringProperty())
+					.property("retired", new BooleanProperty())
+					.property("orderTemplate", new StringProperty())
+					.property("orderTemplateType", new StringProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+					.property("orderType", new RefProperty("#/definitions/OrdertypeGetRef"))
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+					.property("orderType", new RefProperty("#/definitions/OrdertypeGet"))
+					.property("concept", new RefProperty("#/definitions/ConceptGet"));
+		}
+		return modelImpl;
 	}
 	
 	@Override
-	public Model getCREATEModel(Representation representation) {
-		return null;
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+				.property("orderType", new ObjectProperty()
+						.property("uuid", new StringProperty()))
+				.property("orderTemplate", new StringProperty())
+				.property("concept", new StringProperty().example("uuid"))
+				.property("retired", new BooleanProperty());
+	}
+
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 
 	@Override

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
+import io.swagger.models.Model;
 import org.openmrs.OrderSet;
 import org.openmrs.OrderSetMember;
 import org.openmrs.api.context.Context;
@@ -98,6 +99,16 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 		return creatableProperties;
 	}
 	
+	@Override
+	public Model getGETModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+
 	@Override
 	public OrderSetMember getByUniqueId(String uniqueId) {
 		return Context.getOrderSetService().getOrderSetMemberByUuid(uniqueId);

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
@@ -10,11 +10,15 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
 import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.RefProperty;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.OrderSet;
 import org.openmrs.OrderSetMember;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.core.property.EnumProperty;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
@@ -105,17 +109,26 @@ public class OrderSetResource1_12 extends MetadataDelegatingCrudResource<OrderSe
 	}
 	
 	@Override
-	public Model getGETModel(Representation representation) {
-		return null;
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+					.property("operator", new EnumProperty(OrderSet.Operator.class));
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+					.property("orderSetMembers", new ArrayProperty(new RefProperty("#/definitions/OrdersetOrdersetmemberGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+					.property("orderSetMembers", new ArrayProperty(new RefProperty("#/definitions/OrdersetOrdersetmemberGet")));
+		}
+		return modelImpl;
 	}
 	
 	@Override
 	public Model getCREATEModel(Representation representation) {
-		return null;
-	}
-	
-	@Override
-	public Model getUPDATEModel(Representation representation) {
-		return null;
+		return new ModelImpl()
+				.property("operator", new EnumProperty(OrderSet.Operator.class))
+				.property("orderSetMembers", new ArrayProperty(new RefProperty("#/definitions/OrdersetOrdersetmemberCreate")));
 	}
 }

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
+import io.swagger.models.Model;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.OrderSet;
@@ -101,5 +102,20 @@ public class OrderSetResource1_12 extends MetadataDelegatingCrudResource<OrderSe
 		d.addProperty("operator");
 		d.addProperty("orderSetMembers");
 		return d;
+	}
+	
+	@Override
+	public Model getGETModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return null;
 	}
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/AllergyResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/AllergyResource1_8.java
@@ -9,9 +9,17 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Patient;
 import org.openmrs.activelist.Allergy;
+import org.openmrs.activelist.AllergySeverity;
+import org.openmrs.activelist.AllergyType;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -53,6 +61,35 @@ public class AllergyResource1_8 extends BaseActiveListItemResource1_8<Allergy> {
 			return description;
 		}
 		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
+		        .property("allergyType", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(AllergyType.class)))
+		        .property("reaction", new RefProperty("#/definitions/ConceptGetRef"))
+		        .property("severity", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(AllergySeverity.class)))
+		        .property("allergen", new RefProperty("#/definitions/ConceptGetRef"));
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("reaction", new RefProperty("#/definitions/ConceptGet"))
+			        .property("allergen", new RefProperty("#/definitions/ConceptGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("allergyType", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(AllergyType.class)))
+		        .property("reaction", new ObjectProperty()
+		                .property("uuid", new StringProperty()))
+		        .property("severity", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(AllergySeverity.class)))
+		        .property("allergen", new StringProperty());
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/BaseActiveListItemResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/BaseActiveListItemResource1_8.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.activelist.ActiveListItem;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -25,6 +31,25 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
  * {@link ActiveListItem}
  */
 public abstract class BaseActiveListItemResource1_8<T extends ActiveListItem> extends DataDelegatingCrudResource<T> {
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("person", new StringProperty())
+		        .property("startDate", new DateProperty())
+		        .property("comments", new StringProperty())
+		        .property("startObs", new StringProperty())
+		        .property("stopObs", new StringProperty())
+		        
+		        .required("person").required("startDate");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonCreate"))
+			        .property("startObs", new RefProperty("#/definitions/ObsCreate"))
+			        .property("stopObs", new RefProperty("#/definitions/ObsCreate"));
+		}
+		return model;
+	}
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)
@@ -63,6 +88,30 @@ public abstract class BaseActiveListItemResource1_8<T extends ActiveListItem> ex
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty())
+		        .property("startDate", new DateProperty())
+		        .property("endDate", new DateProperty())
+		        .property("comments", new StringProperty())
+		        .property("voided", new BooleanProperty());
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGet"))
+			        .property("activeListType", new StringProperty()) //FIXME type
+			        .property("startObs", new RefProperty("#/definitions/ObsGet"))
+			        .property("stopObs", new RefProperty("#/definitions/ObsGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGetRef"))
+			        .property("activeListType", new StringProperty()) //FIXME type
+			        .property("startObs", new RefProperty("#/definitions/ObsGetRef"))
+			        .property("stopObs", new RefProperty("#/definitions/ObsGetRef"));
+		}
+		return model;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortMemberResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortMemberResource1_8.java
@@ -12,6 +12,10 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Cohort;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
@@ -114,6 +118,40 @@ public class CohortMemberResource1_8 extends DelegatingSubResource<CohortMember1
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof RefRepresentation) {
+			modelImpl
+			        .property("display", new StringProperty());
+		} else if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("display", new StringProperty())
+			        .property("patient", new RefProperty("#/definitions/PatientGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("display", new StringProperty())
+			        .property("patient", new RefProperty("#/definitions/PatientGetRef"));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("patient", new StringProperty().example("uuid"))
+		        .required("patient");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("patient", new RefProperty("#/definitions/PatientCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8.java
@@ -11,6 +11,11 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Cohort;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -85,6 +90,37 @@ public class CohortResource1_8 extends DataDelegatingCrudResource<Cohort> {
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("name", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("voided", new StringProperty())
+			        .property("memberIds", new ArrayProperty(new IntegerProperty())); //FIXME
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("name", new StringProperty())
+		        .property("description", new StringProperty())
+		        .property("memberIds", new ArrayProperty(new IntegerProperty())) //FIXME
+		        .required("name").required("description").required("memberIds");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("name", new StringProperty())
+		        .property("description", new StringProperty())
+		        .required("name").required("description");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8.java
@@ -9,11 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
 import org.openmrs.ConceptClass;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
@@ -63,6 +65,21 @@ public class ConceptClassResource1_8 extends MetadataDelegatingCrudResource<Conc
 		if (conceptClass == null)
 			return;
 		Context.getConceptService().purgeConceptClass(conceptClass);
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return super.getCREATEModel(rep);
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -61,6 +65,25 @@ public class ConceptDatatypeResource1_8 extends MetadataDelegatingCrudResource<C
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("name", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("hl7Abbreviation", new StringProperty())
+			        .property("retired", new BooleanProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return super.getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
@@ -12,6 +12,9 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Concept;
 import org.openmrs.ConceptDescription;
 import org.openmrs.api.context.Context;
@@ -62,6 +65,36 @@ public class ConceptDescriptionResource1_8 extends DelegatingSubResource<Concept
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof RefRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty());
+		} else if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("locale", new StringProperty());
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("locale", new StringProperty());
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("description", new StringProperty())
+		        .property("locale", new StringProperty().example("fr"))
+		        .required("description").required("locale");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptMapResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptMapResource1_8.java
@@ -12,6 +12,9 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Concept;
 import org.openmrs.ConceptMap;
 import org.openmrs.api.context.Context;
@@ -60,6 +63,33 @@ public class ConceptMapResource1_8 extends DelegatingSubResource<ConceptMap, Con
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("display", new StringProperty())
+			        .property("uuid", new StringProperty())
+			        .property("source", new StringProperty()) //FIXME
+			        .property("sourceCode", new StringProperty());
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("display", new StringProperty())
+			        .property("uuid", new StringProperty())
+			        .property("source", new StringProperty()) //FIXME
+			        .property("sourceCode", new StringProperty())
+			        .property("comment", new StringProperty());
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("source", new StringProperty())
+		        .property("sourceCode", new StringProperty())
+		        .required("source").required("sourceCode");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptNameResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptNameResource1_8.java
@@ -13,9 +13,15 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Concept;
 import org.openmrs.ConceptName;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -62,6 +68,39 @@ public class ConceptNameResource1_8 extends DelegatingSubResource<ConceptName, C
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty());
+		
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("name", new StringProperty())
+			        .property("locale", new StringProperty().example("en"))
+			        .property("localePreferred", new BooleanProperty())
+			        .property("conceptNameType", new StringProperty()
+			                ._enum(SwaggerSpecificationCreator.getEnumsAsList(ConceptNameType.class)));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("name", new StringProperty())
+		        .property("locale", new StringProperty().example("en"))
+		        .property("localePreferred", new BooleanProperty()._default(false))
+		        .property("conceptNameType", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(ConceptNameType.class)))
+		        .required("name").required("locale");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("name", new StringProperty()); //FIXME missing props
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -9,6 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
@@ -207,6 +214,72 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty());
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("name", new RefProperty("#/definitions/ConceptNameGet"))
+			        .property("datatype", new RefProperty("#/definitions/ConceptdatatypeGetRef"))
+			        .property("conceptClass", new RefProperty("#/definitions/ConceptclassGetRef"))
+			        .property("set", new BooleanProperty())
+			        .property("version", new StringProperty())
+			        .property("retired", new BooleanProperty())
+			        .property("names", new ArrayProperty(new RefProperty("#/definitions/ConceptNameGetRef"))) //FIXME
+			        .property("descriptions", new ArrayProperty(new RefProperty("#/definitions/ConceptDescriptionGetRef"))) //FIXME
+			        .property("mappings", new ArrayProperty(new RefProperty("#/definitions/ConceptMappingGetRef"))) //FIXME
+			        .property("answers", new ArrayProperty(new ObjectProperty())) //FIXME
+			        .property("setMembers", new ArrayProperty(new ObjectProperty())); //FIXME
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("names", new ArrayProperty(new RefProperty("#/definitions/ConceptNameCreate")))
+		        .property("datatype", new StringProperty().example("uuid"))
+		        .property("set", new BooleanProperty())
+		        .property("version", new StringProperty())
+		        .property("answers", new ArrayProperty(new StringProperty().example("uuid")))
+		        .property("setMembers", new ArrayProperty(new StringProperty().example("uuid")))
+		        
+		        //ConceptNumeric properties
+		        .property("hiNormal", new StringProperty())
+		        .property("hiAbsolute", new StringProperty())
+		        .property("hiCritical", new StringProperty())
+		        .property("lowNormal", new StringProperty())
+		        .property("lowAbsolute", new StringProperty())
+		        .property("lowCritical", new StringProperty())
+		        .property("units", new StringProperty())
+		        .property("allowDecimal", new StringProperty())
+		        .property("displayPrecision", new StringProperty())
+		        
+		        .required("names").required("datatype").required("conceptClass");
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("conceptClass", new StringProperty())
+			        .property("descriptions", new ArrayProperty(new StringProperty()))
+			        .property("mappings", new ArrayProperty(new StringProperty()));
+		}
+		else if (rep instanceof FullRepresentation) {
+			model
+			        .property("conceptClass", new RefProperty("#/definitions/ConceptclassCreate"))
+			        .property("descriptions", new ArrayProperty(new RefProperty("#/definitions/ConceptDescriptionCreate")))
+			        .property("mappings", new ArrayProperty(new RefProperty("#/definitions/ConceptMappingCreate")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("name", new RefProperty("#/definitions/ConceptNameCreate"))
+		        .property("names", new ArrayProperty(new RefProperty("#/definitions/ConceptNameCreate")))
+		        .property("descriptions", new ArrayProperty(new RefProperty("#/definitions/ConceptDescriptionCreate")));
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.ConceptSource;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -64,6 +68,25 @@ public class ConceptSourceResource1_8 extends MetadataDelegatingCrudResource<Con
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		return ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty())
+		        .property("name", new StringProperty())
+		        .property("description", new StringProperty())
+		        .property("hl7Code", new StringProperty())
+		        .property("retired", new BooleanProperty());
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("name", new StringProperty())
+		        .property("description", new StringProperty())
+		        .property("hl7Code", new StringProperty())
+		        .required("name").required("description");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
@@ -11,7 +11,6 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import java.util.List;
 
-import ca.uhn.hl7v2.model.v23.datatype.MO;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.BooleanProperty;
@@ -43,7 +42,7 @@ import org.openmrs.util.OpenmrsConstants;
  */
 @SubClassHandler(supportedClass = DrugOrder.class, supportedOpenmrsVersions = { "1.8.*", "1.9.*" })
 public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<Order, DrugOrder> implements DelegatingSubclassHandler<Order, DrugOrder> {
-	
+
 	public DrugOrderSubclassHandler1_8() {
 		//RESTWS-439
 		//Order subclass fields
@@ -178,11 +177,6 @@ public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<O
 		orderModel.getProperties().remove("orderType");
 		
 		return orderModel;
-	}
-	
-	@Override
-	public Model getUPDATEModel(Representation representation) {
-		return null;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
@@ -11,6 +11,14 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import java.util.List;
 
+import ca.uhn.hl7v2.model.v23.datatype.MO;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.DrugOrder;
 import org.openmrs.Order;
 import org.openmrs.Patient;
@@ -127,6 +135,54 @@ public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<O
 		// DrugOrders have a specific hardcoded value for this property
 		d.removeProperty("orderType");
 		return d;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		OrderResource1_8 orderResource = (OrderResource1_8) Context.getService(RestService.class)
+		        .getResourceBySupportedClass(Order.class);
+		ModelImpl orderModel = (ModelImpl) orderResource.getGETModel(rep);
+		orderModel
+		        .property("dose", new DoubleProperty())
+		        .property("units", new StringProperty())
+		        .property("frequency", new StringProperty())
+		        .property("prn", new BooleanProperty())
+		        .property("complex", new BooleanProperty())
+		        .property("quantity", new IntegerProperty());
+		
+		if (rep instanceof DefaultRepresentation) {
+			orderModel
+			        .property("drug", new RefProperty("#/definitions/DrugGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			orderModel
+			        .property("drug", new RefProperty("#/definitions/DrugGet"));
+		}
+		return orderModel;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		OrderResource1_8 orderResource = (OrderResource1_8) Context.getService(RestService.class)
+		        .getResourceBySupportedClass(Order.class);
+		ModelImpl orderModel = (ModelImpl) orderResource.getCREATEModel(rep);
+		orderModel
+		        .property("dose", new DoubleProperty())
+		        .property("units", new StringProperty())
+		        .property("frequency", new StringProperty())
+		        .property("prn", new BooleanProperty())
+		        .property("complex", new BooleanProperty())
+		        .property("quantity", new IntegerProperty())
+		        .property("drug", new RefProperty("#/definitions/DrugCreate"));
+		
+		// DrugOrders have a specific hardcoded value for this property
+		orderModel.getProperties().remove("orderType");
+		
+		return orderModel;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return null;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugResource1_8.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Drug;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -112,6 +118,57 @@ public class DrugResource1_8 extends MetadataDelegatingCrudResource<Drug> {
 		}
 		//Let the superclass handle this
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("doseStrength", new DoubleProperty())
+			        .property("maximumDailyDose", new DoubleProperty())
+			        .property("minimumDailyDose", new DoubleProperty())
+			        .property("units", new StringProperty())
+			        .property("combination", new BooleanProperty()._default(false));
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("dosageForm", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("route", new RefProperty("#/definitions/ConceptGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("dosageForm", new RefProperty("#/definitions/ConceptGet"))
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("route", new RefProperty("#/definitions/ConceptGet"));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
+		        .property("combination", new BooleanProperty()._default(false))
+		        .property("concept", new StringProperty())
+		        .property("doseStrength", new DoubleProperty())
+		        .property("maximumDailyDose", new DoubleProperty())
+		        .property("minimumDailyDose", new DoubleProperty())
+		        .property("units", new StringProperty())
+		        .property("dosageForm", new StringProperty())
+		        .property("route", new StringProperty())
+		        
+		        .required("combination").required("concept");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptCreate"))
+			        .property("dosageForm", new RefProperty("#/definitions/ConceptCreate"))
+			        .property("route", new RefProperty("#/definitions/ConceptCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep); //FIXME no updatableProperties()
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
@@ -9,6 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Order;
@@ -36,6 +43,8 @@ import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.hibernate.criterion.Projections.property;
 
 /**
  * Resource for Encounters, supporting standard CRUD operations
@@ -82,6 +91,56 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("encounterDatetime", new DateProperty())
+			        .property("provider", new StringProperty()) //FIXME
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("patient", new RefProperty("#/definitions/PatientGetRef")) //FIXME
+			        .property("location", new RefProperty("#/definitions/LocationGetRef")) //FIXME
+			        .property("form", new RefProperty("#/definitions/FormGetRef")) //FIXME
+			        .property("encounterType", new RefProperty("#/definitions/EncountertypeGetRef")) //FIXME
+			        .property("obs", new ArrayProperty(new RefProperty("#/definitions/ObsGetRef"))) //FIXME
+			        .property("orders", new ArrayProperty(new RefProperty("#/definitions/OrderGetRef"))); //FIXME
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("patient", new RefProperty("#/definitions/PatientGet")) //FIXME
+			        .property("location", new RefProperty("#/definitions/LocationGet")) //FIXME
+			        .property("form", new RefProperty("#/definitions/FormGet")) //FIXME
+			        .property("encounterType", new RefProperty("#/definitions/EncountertypeGet")) //FIXME
+			        .property("obs", new ArrayProperty(new RefProperty("#/definitions/ObsGet"))) //FIXME
+			        .property("orders", new ArrayProperty(new RefProperty("#/definitions/OrderGet"))); //FIXME
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("patient", new RefProperty("#/definitions/PatientCreate"))
+		        .property("encounterType", new RefProperty("#/definitions/EncountertypeCreate"))
+		        .property("encounterDatetime", new DateProperty())
+		        .property("location", new RefProperty("#/definitions/LocationCreate"))
+		        .property("form", new RefProperty("#/definitions/FormCreate"))
+		        .property("provider", new StringProperty())
+		        .property("orders", new ArrayProperty(new RefProperty("#/definitions/OrderCreate")))
+		        .property("obs", new ArrayProperty(new RefProperty("#/definitions/ObsCreate")))
+		        
+		        .required("patient").required("encounterType");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8.java
@@ -9,11 +9,14 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
 import org.openmrs.EncounterType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
@@ -38,6 +41,17 @@ public class EncounterTypeResource1_8 extends MetadataDelegatingCrudResource<Enc
 		description.addRequiredProperty("description");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .required("description");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
@@ -12,6 +12,10 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Field;
 import org.openmrs.FieldAnswer;
 import org.openmrs.api.context.Context;
@@ -74,6 +78,38 @@ public class FieldAnswerResource1_8 extends DelegatingSubResource<FieldAnswer, F
 			return description;
 		}
 		return null;
+	}
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("field", new RefProperty("#/definitions/FieldGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("field", new RefProperty("#/definitions/FieldGet"));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("concept", new StringProperty().example("uuid"))
+		        .property("field", new StringProperty().example("uuid"))
+		        .required("field").required("concept");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptCreate"))
+			        .property("field", new RefProperty("#/definitions/FieldCreate"));
+		}
+		return model;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Field;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -31,6 +36,45 @@ import java.util.List;
 @Resource(name = RestConstants.VERSION_1 + "/field", supportedClass = Field.class, supportedOpenmrsVersions = { "1.8.*",
         "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*" })
 public class FieldResource1_8 extends MetadataDelegatingCrudResource<Field> {
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("tableName", new StringProperty())
+			        .property("attributeName", new StringProperty())
+			        .property("defaultValue", new StringProperty())
+			        .property("selectMultiple", new BooleanProperty()._default(false));
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("fieldType", new RefProperty("#/definitions/FieldtypeGetRef"))
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("fieldType", new RefProperty("#/definitions/FieldtypeGet"))
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("fieldType", new RefProperty("#/definitions/FieldtypeCreate"))
+		        .property("selectMultiple", new BooleanProperty()._default(false))
+		        .property("concept", new RefProperty("#/definitions/ConceptCreate"))
+		        .property("tableName", new StringProperty())
+		        .property("attributeName", new StringProperty())
+		        .property("defaultValue", new StringProperty())
+		        
+		        .required("fieldType").required("selectMultiple");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return new ModelImpl(); //FIXME missing props
+	}
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
 import org.openmrs.FieldType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -28,6 +31,25 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 @Resource(name = RestConstants.VERSION_1 + "/fieldtype", supportedClass = FieldType.class, supportedOpenmrsVersions = {
         "1.8.*", "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*" })
 public class FieldTypeResource1_8 extends MetadataDelegatingCrudResource<FieldType> {
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("isSet", new BooleanProperty()._default(false));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return super.getCREATEModel(rep); //FIXME missing props
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
+	}
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
@@ -12,6 +12,13 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Form;
 import org.openmrs.FormField;
 import org.openmrs.api.context.Context;
@@ -34,6 +41,64 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 @SubResource(parent = FormResource1_8.class, path = "formfield", supportedClass = FormField.class, supportedOpenmrsVersions = {
         "1.8.*", "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*" })
 public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form, FormResource1_8> {
+	
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("fieldNumber", new IntegerProperty())
+			        .property("fieldPart", new StringProperty())
+			        .property("pageNumber", new IntegerProperty())
+			        .property("minOccurs", new IntegerProperty())
+			        .property("maxOccurs", new IntegerProperty())
+			        .property("required", new BooleanProperty()._default(false))
+			        .property("sortWeight", new FloatProperty())
+			        .property("retired", new BooleanProperty()); //FIXME
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("parent", new RefProperty("#/definitions/FormFormfieldGetRef"))
+			        .property("form", new RefProperty("#/definitions/FormGetRef"))
+			        .property("field", new RefProperty("#/definitions/FieldGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("parent", new RefProperty("#/definitions/FormFormfieldGet"))
+			        .property("form", new RefProperty("#/definitions/FormGet"))
+			        .property("field", new RefProperty("#/definitions/FieldGet"));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl() //FIXME validate if correct
+		        .property("form", new StringProperty().example("uuid"))
+		        .property("field", new StringProperty().example("uuid"))
+		        .property("required", new BooleanProperty()._default(false))
+		        .property("parent", new StringProperty().example("uuid"))
+		        .property("fieldNumber", new IntegerProperty())
+		        .property("fieldPart", new StringProperty())
+		        .property("pageNumber", new IntegerProperty())
+		        .property("minOccurs", new IntegerProperty())
+		        .property("maxOccurs", new IntegerProperty())
+		        .property("sortWeight", new BooleanProperty()._default(false))
+		        
+		        .required("form").required("field").required("required");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("form", new RefProperty("#/definitions/FormCreate"))
+			        .property("field", new RefProperty("#/definitions/FieldCreate"))
+			        .property("parent", new RefProperty("#/definitions/FormFormfieldCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
+	}
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8.java
@@ -9,6 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Form;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -87,6 +94,57 @@ public class FormResource1_8 extends MetadataDelegatingCrudResource<Form> {
 		description.addProperty("template");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("name", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("version", new StringProperty())
+			        .property("build", new IntegerProperty())
+			        .property("published", new BooleanProperty()._default(false))
+			        .property("retired", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("encounterType", new RefProperty("#/definitions/EncountertypeGetRef"))
+			        .property("formFields", new ArrayProperty(new RefProperty("#/definitions/FormFormfieldGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("encounterType", new RefProperty("#/definitions/EncountertypeGet"))
+			        .property("formFields", new ArrayProperty(new RefProperty("#/definitions/FormFormfieldGet")));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
+		        .property("version", new StringProperty())
+		        .property("encounterType", new StringProperty())
+		        .property("build", new IntegerProperty())
+		        .property("published", new BooleanProperty()._default(false))
+		        .property("formFields", new ArrayProperty(new StringProperty()))
+		        .property("xslt", new StringProperty())
+		        .property("template", new StringProperty())
+		        
+		        .required("version");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("encounterType", new RefProperty("#/definitions/EncountertypeCreate"))
+			        .property("formFields", new ArrayProperty(new RefProperty("#/definitions/FormFormfieldCreate")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
@@ -122,11 +122,6 @@ public class HL7MessageResource1_8 extends DataDelegatingCrudResource<IncomingHl
 		        .required("hl7");
 	}
 	
-	@Override
-	public Model getUPDATEModel(Representation representation) {
-		return null;
-	}
-	
 	/**
 	 * It needs to be overwritten to allow for hidden properties: source, sourceKey and data. They
 	 * are automatically extracted from the hl7 property and populated in

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -88,6 +93,38 @@ public class HL7MessageResource1_8 extends DataDelegatingCrudResource<IncomingHl
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
 		description.addRequiredProperty("hl7");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("messageState", new IntegerProperty());
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("source", new RefProperty("#/definitions/Hl7sourceGet"))
+			        .property("sourceKey", new StringProperty())
+			        .property("data", new StringProperty())
+			        .property("messageState", new IntegerProperty());
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("hl7", new StringProperty()) //FIXME TYPE
+		        .required("hl7");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return null;
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
 import org.openmrs.api.context.Context;
 import org.openmrs.hl7.HL7Source;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -53,6 +55,23 @@ public class HL7SourceResource1_8 extends MetadataDelegatingCrudResource<HL7Sour
 		description.addRequiredProperty("description");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        
+		        .required("description");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationResource1_8.java
@@ -11,6 +11,11 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.collections.CollectionUtils;
 import org.openmrs.Location;
 import org.openmrs.LocationTag;
@@ -132,6 +137,65 @@ public class LocationResource1_8 extends MetadataDelegatingCrudResource<Location
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("address1", new StringProperty())
+			        .property("address2", new StringProperty())
+			        .property("cityVillage", new StringProperty())
+			        .property("stateProvince", new StringProperty())
+			        .property("country", new StringProperty())
+			        .property("postalCode", new StringProperty())
+			        .property("latitude", new StringProperty())
+			        .property("longitude", new StringProperty())
+			        .property("countyDistrict", new StringProperty())
+			        .property("address3", new StringProperty())
+			        .property("address4", new StringProperty())
+			        .property("address5", new StringProperty())
+			        .property("address6", new StringProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("tags", new ArrayProperty(new RefProperty("#/definitions/LocationtagGetRef")))
+			        .property("parentLocation", new RefProperty("#/definitions/LocationGetRef"))
+			        .property("childLocations", new ArrayProperty(new RefProperty("#/definitions/LocationGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("tags", new ArrayProperty(new RefProperty("#/definitions/LocationtagGet")))
+			        .property("parentLocation", new RefProperty("#/definitions/LocationGet"))
+			        .property("childLocations", new ArrayProperty(new RefProperty("#/definitions/LocationGet")));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("address1", new StringProperty())
+		        .property("address2", new StringProperty())
+		        .property("cityVillage", new StringProperty())
+		        .property("stateProvince", new StringProperty())
+		        .property("country", new StringProperty())
+		        .property("postalCode", new StringProperty())
+		        .property("latitude", new StringProperty())
+		        .property("longitude", new StringProperty())
+		        .property("countyDistrict", new StringProperty())
+		        .property("address3", new StringProperty())
+		        .property("address4", new StringProperty())
+		        .property("address5", new StringProperty())
+		        .property("address6", new StringProperty())
+		        .property("tags", new ArrayProperty(new StringProperty()))
+		        .property("parentLocation", new StringProperty())
+		        .property("childLocations", new ArrayProperty(new StringProperty()));
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationTagResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationTagResource1_8.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.LocationTag;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
@@ -87,6 +91,18 @@ public class LocationTagResource1_8 extends MetadataDelegatingCrudResource<Locat
 		description.addProperty("retireReason");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("retired", new BooleanProperty())
+		        .property("retiredReason", new StringProperty());
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleActionResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleActionResource1_8.java
@@ -9,8 +9,15 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleException;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.helper.ModuleAction;
 import org.openmrs.module.webservices.helper.ModuleFactoryWrapper;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -226,6 +233,25 @@ public class ModuleActionResource1_8 extends BaseDelegatingResource<ModuleAction
 		description.addProperty("allModules");
 		description.addRequiredProperty("action", "action");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return ((ModelImpl) super.getGETModel(rep))
+		        .property("modules", new ArrayProperty(new RefProperty("#/definitions/ModuleGetRef")))
+		        .property("action", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(ModuleAction.Action.class)));
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("modules", new ArrayProperty(new StringProperty().example("moduleId")))
+		        .property("allModules", new BooleanProperty())
+		        .property("action", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(ModuleAction.Action.class)))
+		        
+		        .required("action");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.io.FileUtils;
 import org.openmrs.module.Module;
 import org.openmrs.module.webservices.helper.ModuleFactoryWrapper;
@@ -98,6 +103,39 @@ public class ModuleResource1_8 extends BaseDelegatingReadableResource<Module> im
 			description.addSelfLink();
 			return description;
 		}
+		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("name", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("started", new BooleanProperty()) //FIXME check type
+			        .property("startupErrorMessage", new StringProperty()); //FIXME add-link: action
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("packageName", new StringProperty())
+			        .property("author", new StringProperty())
+			        .property("version", new StringProperty())
+			        .property("requireOpenmrsVersion", new StringProperty())
+			        .property("awareOfModules", new ArrayProperty(new StringProperty())) //FIXME check type
+			        .property("requiredModules", new ArrayProperty(new StringProperty()));
+		} else if (rep instanceof RefRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
 		return null;
 	}
 	

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -9,6 +9,14 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.ConceptNumeric;
@@ -155,6 +163,69 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		description.addProperty("valueModifier");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("obsDatetime", new DateProperty())
+			        .property("accessionNumber", new StringProperty())
+			        .property("comment", new StringProperty())
+			        .property("voided", new BooleanProperty())
+			        .property("value", new StringProperty())
+			        .property("valueModifier", new StringProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("person", new RefProperty("#/definitions/PersonGetRef"))
+			        .property("obsGroup", new RefProperty("#/definitions/ObsGetRef"))
+			        .property("groupMembers", new ArrayProperty(new RefProperty("#/definitions/ObsGetRef")))
+			        .property("valueCodedName", new RefProperty("#/definitions/ConceptNameGetRef"))
+			        .property("location", new RefProperty("#/definitions/LocationGetRef"))
+			        .property("order", new RefProperty("#/definitions/OrderGetRef"))
+			        .property("encounter", new RefProperty("#/definitions/EncounterGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("person", new RefProperty("#/definitions/PersonGet"))
+			        .property("obsGroup", new RefProperty("#/definitions/ObsGet"))
+			        .property("groupMembers", new ArrayProperty(new RefProperty("#/definitions/ObsGet")))
+			        .property("valueCodedName", new RefProperty("#/definitions/ConceptNameGet"))
+			        .property("location", new RefProperty("#/definitions/LocationGet"))
+			        .property("order", new RefProperty("#/definitions/OrderGet"))
+			        .property("encounter", new RefProperty("#/definitions/EncounterGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("person", new StringProperty().example("uuid"))
+		        .property("obsDatetime", new DateTimeProperty())
+		        .property("concept", new StringProperty().example("uuid"))
+		        .property("location", new StringProperty())
+		        .property("order", new StringProperty())
+		        .property("encounter", new StringProperty())
+		        .property("accessionNumber", new StringProperty())
+		        .property("groupMembers", new ArrayProperty(new StringProperty()))
+		        .property("valueCodedName", new StringProperty())
+		        .property("comment", new StringProperty())
+		        .property("voided", new BooleanProperty())
+		        .property("value", new StringProperty())
+		        .property("valueModifier", new StringProperty())
+		        
+		        .required("person").required("obsDatetime").required("concept");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
@@ -11,6 +11,12 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.api.OrderService.ORDER_STATUS;
@@ -190,6 +196,80 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 		d.addProperty("discontinuedReasonNonCoded");
 		d.addProperty("accessionNumber");
 		return d;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("instructions", new StringProperty())
+			        .property("startDate", new DateProperty())
+			        .property("autoExpireDate", new DateProperty())
+			        .property("accessionNumber", new StringProperty())
+			        .property("discontinuedDate", new DateProperty())
+			        .property("discontinuedReasonNonCoded", new StringProperty())
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("orderType", new RefProperty("#/definitions/OrdertypeGetRef"))
+			        .property("patient", new RefProperty("#/definitions/PatientGetRef"))
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("encounter", new RefProperty("#/definitions/EncounterGetRef"))
+			        .property("orderer", new RefProperty("#/definitions/UserGetRef"))
+			        .property("discontinuedBy", new RefProperty("#/definitions/UserGetRef"))
+			        .property("discontinuedReason", new RefProperty("#/definitions/ConceptGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("orderType", new RefProperty("#/definitions/OrdertypeGet"))
+			        .property("patient", new RefProperty("#/definitions/PatientGet"))
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("encounter", new RefProperty("#/definitions/EncounterGet"))
+			        .property("orderer", new RefProperty("#/definitions/UserGet"))
+			        .property("discontinuedBy", new RefProperty("#/definitions/UserGet"))
+			        .property("discontinuedReason", new RefProperty("#/definitions/ConceptGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("orderType", new StringProperty().example("uuid"))
+		        .property("patient", new StringProperty().example("uuid"))
+		        .property("concept", new StringProperty().example("uuid"))
+		        .property("instructions", new StringProperty())
+		        .property("startDate", new DateProperty())
+		        .property("autoExpireDate", new DateProperty())
+		        .property("encounter", new StringProperty().example("uuid"))
+		        .property("orderer", new StringProperty().example("uuid"))
+		        .property("discontinuedBy", new StringProperty().example("uuid"))
+		        .property("discontinuedDate", new DateProperty())
+		        .property("discontinuedReason", new RefProperty("#/definitions/ConceptCreate"))
+		        .property("discontinuedReasonNonCoded", new StringProperty())
+		        .property("accessionNumber", new StringProperty())
+		        
+		        .required("orderType").required("patient").required("concept");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("orderType", new RefProperty("#/definitions/OrdertypeCreate"))
+			        .property("patient", new RefProperty("#/definitions/PatientCreate"))
+			        .property("concept", new RefProperty("#/definitions/ConceptCreate"))
+			        .property("encounter", new RefProperty("#/definitions/EncounterCreate"))
+			        .property("orderer", new RefProperty("#/definitions/UserCreate"))
+			        .property("discontinuedBy", new RefProperty("#/definitions/UserCreate"))
+			        .property("discontinuedReason", new RefProperty("#/definitions/ConceptCreate"));
+		}
+		//FIXME missing prop: type
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderTypeResource1_8.java
@@ -60,5 +60,4 @@ public class OrderTypeResource1_8 extends MetadataDelegatingCrudResource<OrderTy
 		}
 		Context.getOrderService().purgeOrderType(delegate);
 	}
-	
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
@@ -10,6 +10,11 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import org.apache.commons.lang3.StringUtils;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
@@ -126,6 +131,51 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("identifier", new StringProperty())
+			        .property("preferred", new BooleanProperty()._default(false))
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("identifierType", new RefProperty("#/definitions/PatientidentifiertypeGetRef"))
+			        .property("location", new RefProperty("#/definitions/LocationGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("identifierType", new RefProperty("#/definitions/PatientidentifiertypeGet"))
+			        .property("location", new RefProperty("#/definitions/LocationGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("identifier", new StringProperty())
+		        .property("identifierType", new StringProperty().example("uuid"))
+		        .property("location", new StringProperty().example("uuid"))
+		        .property("preferred", new BooleanProperty()._default(false))
+		        
+		        .required("identifier").required("identifierType");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("identifierType", new RefProperty("#/definitions/PatientidentifiertypeCreate"))
+			        .property("location", new RefProperty("#/definitions/LocationCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	private PatientService service() {

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8.java
@@ -9,9 +9,14 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -74,7 +79,7 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 			description.addProperty("validator");
 			description.addProperty("locationBehavior");
 			description.addProperty("uniquenessBehavior");
-			description.addProperty("validator");
+			description.addProperty("validator"); //FIXME duplicate
 			description.addProperty("retired");
 			description.addProperty("auditInfo");
 			description.addSelfLink();
@@ -108,6 +113,41 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("format", new StringProperty())
+			        .property("formatDescription", new StringProperty())
+			        .property("required", new BooleanProperty())
+			        .property("checkDigit", new BooleanProperty())
+			        .property("validator", new StringProperty())
+			        .property("locationBehavior", new StringProperty()
+			                ._enum(SwaggerSpecificationCreator.getEnumsAsList(PatientIdentifierType.LocationBehavior.class)))
+			        .property("uniquenessBehavior", new StringProperty()); //FIXME check type
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("format", new StringProperty())
+		        .property("formatDescription", new StringProperty())
+		        .property("required", new BooleanProperty())
+		        .property("checkDigit", new BooleanProperty())
+		        .property("validator", new StringProperty())
+		        .property("locationBehavior", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(PatientIdentifierType.LocationBehavior.class)))
+		        .property("uniquenessBehavior", new StringProperty()); //FIXME check type
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.Person;
@@ -39,6 +39,12 @@ import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.module.webservices.validation.ValidateUtil;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * {@link Resource} for Patients, supporting standard CRUD operations
@@ -134,6 +140,50 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 			return description;
 		}
 		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		//FIXME check uuid, display in ref rep
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("identifiers", new ArrayProperty(new RefProperty("#/definitions/PatientIdentifierGetRef")))
+			        .property("preferred", new BooleanProperty()._default(false))
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("person", new StringProperty().example("uuid"))
+		        .property("identifiers", new ArrayProperty(new RefProperty("#/definitions/PatientIdentifierCreate")))
+		        
+		        .required("person").required("identifiers");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("person", new RefProperty("#/definitions/PersonGet"))
+		        
+		        .required("person");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientStateResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientStateResource1_8.java
@@ -9,6 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.PatientProgram;
 import org.openmrs.PatientState;
 import org.openmrs.ProgramWorkflow;
@@ -169,5 +176,46 @@ public class PatientStateResource1_8 extends DelegatingSubResource<PatientState,
 		updatableProperties.addProperty("endDate");
 		updatableProperties.addProperty("voided");
 		return updatableProperties;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof RefRepresentation || rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("startDate", new DateProperty())
+			        .property("endDate", new DateProperty())
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("state", new RefProperty("#/definitions/WorkflowStateGet"));
+		} else if (rep instanceof RefRepresentation) {
+			model
+			        .property("state", new RefProperty("#/definitions/WorkflowStateGetRef"))
+			        .property("patientProgram", new ObjectProperty()); //FIXME type
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("state", new RefProperty("#/definitions/WorkflowStateGetRef"))
+			        .property("patientProgram", new ObjectProperty()); //FIXME type
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("state", new RefProperty("#/definitions/WorkflowStateCreate"))
+		        
+		        .required("state");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("startDate", new DateProperty())
+		        .property("endDate", new DateProperty())
+		        .property("voided", new BooleanProperty());
 	}
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Person;
 import org.openmrs.PersonAddress;
 import org.openmrs.api.context.Context;
@@ -133,6 +138,61 @@ public class PersonAddressResource1_8 extends DelegatingSubResource<PersonAddres
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty());
+		
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("preferred", new BooleanProperty()._default(false))
+			        .property("address1", new StringProperty())
+			        .property("address2", new StringProperty())
+			        .property("cityVillage", new StringProperty())
+			        .property("stateProvince", new StringProperty())
+			        .property("country", new StringProperty())
+			        .property("postalCode", new StringProperty())
+			        .property("countyDistrict", new StringProperty())
+			        .property("address3", new StringProperty())
+			        .property("address4", new StringProperty())
+			        .property("address5", new StringProperty())
+			        .property("address6", new StringProperty())
+			        .property("startDate", new DateProperty())
+			        .property("endDate", new DateProperty())
+			        .property("latitude", new StringProperty())
+			        .property("longitude", new StringProperty())
+			        .property("voided", new BooleanProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("preferred", new BooleanProperty()._default(false))
+		        .property("address1", new StringProperty())
+		        .property("address2", new StringProperty())
+		        .property("cityVillage", new StringProperty())
+		        .property("stateProvince", new StringProperty())
+		        .property("country", new StringProperty())
+		        .property("postalCode", new StringProperty())
+		        .property("countyDistrict", new StringProperty())
+		        .property("address3", new StringProperty())
+		        .property("address4", new StringProperty())
+		        .property("address5", new StringProperty())
+		        .property("address6", new StringProperty())
+		        .property("startDate", new DateProperty())
+		        .property("endDate", new DateProperty())
+		        .property("latitude", new StringProperty())
+		        .property("longitude", new StringProperty());
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Attributable;
 import org.openmrs.Concept;
 import org.openmrs.Person;
@@ -137,6 +142,48 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("display", new StringProperty())
+			        .property("uuid", new StringProperty())
+			        .property("value", new StringProperty())
+			        .property("attributeType", new RefProperty("#/definitions/PersonattributetypeGetRef"))
+			        .property("voided", new BooleanProperty());
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("display", new StringProperty())
+			        .property("uuid", new StringProperty())
+			        .property("value", new StringProperty())
+			        .property("attributeType", new RefProperty("#/definitions/PersonattributetypeGetRef"))
+			        .property("voided", new BooleanProperty())
+			        .property("hydratedObject", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("attributeType", new StringProperty().example("uuid"))
+		        .property("value", new StringProperty())
+		        .property("hydratedObject", new StringProperty().example("uuid"))
+		        
+		        .required("attributeType");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("attributeType", new RefProperty("#/definitions/PersonattributetypeCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeTypeResource1_8.java
@@ -9,6 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Concept;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.api.PersonService;
@@ -104,6 +111,44 @@ public class PersonAttributeTypeResource1_8 extends MetadataDelegatingCrudResour
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("format", new StringProperty())
+			        .property("foreignKey", new IntegerProperty())
+			        .property("sortWeight", new DoubleProperty())
+			        .property("searchable", new BooleanProperty()._default(false));
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("editPrivilege", new RefProperty("#/definitions/PrivilegeGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("editPrivilege", new RefProperty("#/definitions/PrivilegeGet"))
+			        .property("concept", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("format", new StringProperty().example("java.lang.String"))
+		        .property("foreignKey", new IntegerProperty())
+		        .property("sortWeight", new DoubleProperty())
+		        .property("searchable", new BooleanProperty()._default(false))
+		        .property("editPrivilege", new RefProperty("#/definitions/PrivilegeCreate"))
+		        
+		        .required("description");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonNameResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonNameResource1_8.java
@@ -9,11 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Person;
 import org.openmrs.PersonName;
 import org.openmrs.api.context.Context;
@@ -31,6 +30,11 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * {@link Resource} for PersonNames, supporting standard CRUD operations
@@ -99,6 +103,51 @@ public class PersonNameResource1_8 extends DelegatingSubResource<PersonName, Per
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("display", new StringProperty())
+			        .property("uuid", new StringProperty())
+			        .property("givenName", new StringProperty())
+			        .property("middleName", new StringProperty())
+			        .property("familyName", new StringProperty())
+			        .property("familyName2", new StringProperty())
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("preferred", new BooleanProperty())
+			        .property("prefix", new StringProperty())
+			        .property("familyNamePrefix", new StringProperty())
+			        .property("familyNameSuffix", new StringProperty())
+			        .property("degree", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("givenName", new StringProperty())
+		        .property("middleName", new StringProperty())
+		        .property("familyName", new StringProperty())
+		        .property("familyName2", new StringProperty())
+		        .property("preferred", new BooleanProperty()._default(false))
+		        .property("prefix", new StringProperty())
+		        .property("familyNamePrefix", new StringProperty())
+		        .property("familyNameSuffix", new StringProperty())
+		        .property("degree", new StringProperty())
+		        
+		        .required("givenName").required("familyName");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
@@ -14,6 +14,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Person;
 import org.openmrs.PersonAddress;
 import org.openmrs.PersonAttribute;
@@ -131,6 +140,73 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 		description.addRequiredProperty("dead");
 		description.addProperty("deathDate");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("gender", new StringProperty()._enum("M")._enum("F"))
+			        .property("age", new IntegerProperty())
+			        .property("birthdate", new DateTimeProperty())
+			        .property("birthdateEstimated", new BooleanProperty())
+			        .property("dead", new BooleanProperty())
+			        .property("deathDate", new DateProperty())
+			        .property("causeOfDeath", new StringProperty())
+			        .property("attributes", new ArrayProperty(new RefProperty("#/definitions/PersonAttributeGetRef")))
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("preferredName", new RefProperty("#/definitions/PersonNameGetRef"))
+			        .property("preferredAddress", new RefProperty("#/definitions/PersonAddressGetRef"));
+			
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("preferredName", new RefProperty("#/definitions/PersonNameGet"))
+			        .property("preferredAddress", new RefProperty("#/definitions/PersonAddressGet"))
+			        .property("names", new ArrayProperty(new RefProperty("#/definitions/PersonNameGet")))
+			        .property("addresses", new ArrayProperty(new RefProperty("#/definitions/PersonAddressGet")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		ModelImpl model = new ModelImpl()
+		        .property("names", new ArrayProperty(new RefProperty("#/definitions/PersonNameCreate")))
+		        .property("gender", new StringProperty()._enum("M")._enum("F"))
+		        .property("age", new IntegerProperty())
+		        .property("birthdate", new DateProperty())
+		        .property("birthdateEstimated", new BooleanProperty()._default(false))
+		        .property("dead", new BooleanProperty()._default(false))
+		        .property("deathDate", new DateProperty())
+		        .property("causeOfDeath", new StringProperty())
+		        .property("addresses", new ArrayProperty(new RefProperty("#/definitions/PersonAddressCreate")))
+		        .property("attributes", new ArrayProperty(new RefProperty("#/definitions/PersonAttributeCreate")));
+		
+		model.setRequired(Arrays.asList("names", "gender"));
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("dead", new BooleanProperty())
+		        .property("causeOfDeath", new StringProperty())
+		        .property("deathDate", new DateProperty())
+		        .property("age", new IntegerProperty())
+		        .property("gender", new StringProperty()._enum("M")._enum("F"))
+		        .property("birthdate", new DateProperty())
+		        .property("birthdateEstimated", new BooleanProperty()._default(false))
+		        .property("preferredName", new StringProperty().example("uuid"))
+		        .property("preferredAddress", new StringProperty().example("uuid"))
+		        .property("attributes", new ArrayProperty(new RefProperty("#/definitions/PersonAttributeCreate")))
+		        
+		        .required("dead").required("causeOfDeath");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Privilege;
 import org.openmrs.api.context.Context;
@@ -88,6 +91,22 @@ public class PrivilegeResource1_8 extends MetadataDelegatingCrudResource<Privile
 		description.addProperty("description");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep); //FIXME
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return super.getCREATEModel(rep);
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("description", new StringProperty());
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProblemResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProblemResource1_8.java
@@ -9,9 +9,16 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Patient;
 import org.openmrs.activelist.Problem;
+import org.openmrs.activelist.ProblemModifier;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -31,6 +38,27 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
  */
 @Resource(name = RestConstants.VERSION_1 + "/problem", supportedClass = Problem.class, supportedOpenmrsVersions = { "1.8.*" })
 public class ProblemResource1_8 extends BaseActiveListItemResource1_8<Problem> {
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("modifier", new StringProperty()
+			                ._enum(SwaggerSpecificationCreator.getEnumsAsList(ProblemModifier.class)))
+			        .property("sortWeight", new DoubleProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("problem", new RefProperty("#/definitions/ConceptGetRef"));
+			
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("problem", new RefProperty("#/definitions/ConceptGet"));
+			
+		}
+		return model;
+	}
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)
@@ -64,6 +92,17 @@ public class ProblemResource1_8 extends BaseActiveListItemResource1_8<Problem> {
 		description.addProperty("sortWeight");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("problem", new RefProperty("#/definitions/ConceptCreate"))
+		        .property("modifier", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(ProblemModifier.class)))
+		        .property("sortWeight", new DoubleProperty())
+		        
+		        .required("problem");
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Patient;
 import org.openmrs.PatientProgram;
 import org.openmrs.api.PatientService;
@@ -110,6 +116,59 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 		d.addProperty("location");
 		d.addProperty("voided");
 		return d;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("dateEnrolled", new DateProperty())
+			        .property("dateCompleted", new DateProperty())
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("patient", new RefProperty("#/definitions/PatientGetRef"))
+			        .property("program", new RefProperty("#/definitions/ProgramGetRef"))
+			        .property("location", new RefProperty("#/definitions/LocationGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("patient", new RefProperty("#/definitions/PatientGet"))
+			        .property("program", new RefProperty("#/definitions/ProgramGet"))
+			        .property("location", new RefProperty("#/definitions/LocationGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("patient", new StringProperty().example("uuid"))
+		        .property("program", new StringProperty().example("uuid"))
+		        .property("dateEnrolled", new DateProperty())
+		        .property("dateCompleted", new DateProperty())
+		        .property("location", new StringProperty().example("uuid"))
+		        .property("voided", new BooleanProperty())
+		        
+		        .required("patient").required("program").required("dateEnrolled");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("patient", new RefProperty("#/definitions/PatientCreate"))
+			        .property("program", new RefProperty("#/definitions/ProgramCreate"))
+			        .property("location", new RefProperty("#/definitions/LocationCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("dateEnrolled", new DateProperty())
+		        .property("dateCompleted", new DateProperty()); //FIXME missing props
+		
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramResource1_8.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Program;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -105,6 +111,43 @@ public class ProgramResource1_8 extends MetadataDelegatingCrudResource<Program> 
 		
 		description.addProperty("retired");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("allWorkflows", new ArrayProperty(new RefProperty("#/definitions/WorkflowGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("allWorkflows", new ArrayProperty(new RefProperty("#/definitions/WorkflowGet")));
+		} else if (rep instanceof RefRepresentation) {
+			model
+			        .property("allWorkflows", new ArrayProperty(new RefProperty("#/definitions/WorkflowGetRef")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
+		        .property("concept", new StringProperty().example("uuid"))
+		        .property("retired", new BooleanProperty())
+		        
+		        .required("concept").required("description");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
 	}
 	
 	@Override

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowResource1_8.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.RefProperty;
 import org.openmrs.Program;
 import org.openmrs.ProgramWorkflow;
 import org.openmrs.api.context.Context;
@@ -61,6 +65,26 @@ public class ProgramWorkflowResource1_8 extends MetadataDelegatingCrudResource<P
 			return description;
 		}
 		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("states", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("states", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateGet")));
+		} else if (rep instanceof RefRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("states", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateGet")));
+			//FIXME should remove 'description'?
+		}
+		return model;
 	}
 	
 	@Override

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowStateResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowStateResource1_8.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Program;
 import org.openmrs.ProgramWorkflow;
 import org.openmrs.ProgramWorkflowState;
@@ -113,5 +118,34 @@ public class ProgramWorkflowStateResource1_8 extends DelegatingSubResource<Progr
 			return description;
 		}
 		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("retired", new BooleanProperty())
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("retired", new BooleanProperty())
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"));
+		} else if (rep instanceof RefRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("retired", new BooleanProperty())
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
 	}
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationShipTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationShipTypeResource1_8.java
@@ -10,6 +10,10 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import org.apache.commons.lang.StringUtils;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.RelationshipType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -119,6 +123,36 @@ public class RelationShipTypeResource1_8 extends MetadataDelegatingCrudResource<
 		description.addProperty("weight");
 		description.addProperty("description");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("aIsToB", new StringProperty())
+			        .property("bIsToA", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("weight", new IntegerProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("aIsToB", new StringProperty())
+		        .property("bIsToA", new StringProperty())
+		        .property("weight", new IntegerProperty())
+		        
+		        .required("aIsToB").required("bIsToA");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Person;
 import org.openmrs.Relationship;
 import org.openmrs.api.context.Context;
@@ -144,5 +150,54 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 		description.removeProperty("personB");
 		description.addProperty("voided");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("personA", new RefProperty("#/definitions/PersonGetRef"))
+			        .property("relationshipType", new RefProperty("#/definitions/RelationshiptypeGetRef"))
+			        .property("personB", new RefProperty("#/definitions/PersonGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("personA", new RefProperty("#/definitions/PersonGet"))
+			        .property("relationshipType", new RefProperty("#/definitions/RelationshiptypeGet"))
+			        .property("personB", new RefProperty("#/definitions/PersonGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("personA", new StringProperty().example("uuid"))
+		        .property("relationshipType", new StringProperty().example("uuid"))
+		        .property("personB", new StringProperty().example("uuid"))
+		        .property("startDate", new DateProperty())
+		        .property("endDate", new DateProperty())
+		        
+		        .required("personA").required("relationshipType").required("personB");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("personA", new RefProperty("#/definitions/PersonCreate"))
+			        
+			        .property("relationshipType", new RefProperty("#/definitions/RelationshiptypeCreate"))
+			        .property("personB", new RefProperty("#/definitions/PersonCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("voided", new BooleanProperty()); //FIXME missing properties
 	}
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Privilege;
 import org.openmrs.Role;
@@ -119,6 +124,38 @@ public class RoleResource1_8 extends MetadataDelegatingCrudResource<Role> {
 		description.addProperty("inheritedRoles");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("privileges", new ArrayProperty(new RefProperty("#/definitions/PrivilegeGetRef")))
+			        .property("inheritedRoles", new ArrayProperty(new RefProperty("#/definitions/RoleGetRef")));
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("privileges", new ArrayProperty(new RefProperty("#/definitions/PrivilegeGet")))
+			        .property("inheritedRoles", new ArrayProperty(new RefProperty("#/definitions/RoleGet")))
+			        .property("allInheritedRoles", new ArrayProperty(new RefProperty("#/definitions/RoleGet")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("privileges", new ArrayProperty(new RefProperty("#/definitions/PrivilegeCreate")))
+		        .property("inheritedRoles", new ArrayProperty(new RefProperty("#/definitions/RoleCreate")));
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("description", new StringProperty())
+		        .property("privileges", new ArrayProperty(new RefProperty("#/definitions/PrivilegeCreate")))
+		        .property("inheritedRoles", new ArrayProperty(new RefProperty("#/definitions/RoleCreate")));
 	}
 	
 	/**

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
@@ -16,6 +16,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Role;
@@ -125,6 +132,48 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 		description.addProperty("secretQuestion");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		//FIXME check valid supportedClass
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("username", new StringProperty())
+			        .property("systemId", new StringProperty())
+			        .property("userProperties", new MapProperty()); //FIXME type
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGetRef"))
+			        .property("privileges", new ArrayProperty(new RefProperty("#/definitions/PrivilegeGetRef")))
+			        .property("roles", new ArrayProperty(new RefProperty("#/definitions/RoleGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGet"))
+			        .property("privileges", new ArrayProperty(new RefProperty("#/definitions/PrivilegeGet")))
+			        .property("roles", new ArrayProperty(new RefProperty("#/definitions/RoleGet")))
+			        .property("allRoles", new ArrayProperty(new RefProperty("#/definitions/RoleGet")))
+			        .property("proficientLocales", new ArrayProperty(new ObjectProperty()))
+			        .property("secretQuestion", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("username", new StringProperty())
+		        .property("password", new StringProperty())
+		        .property("person", new RefProperty("#/definitions/PersonCreate"))
+		        .property("systemId", new StringProperty())
+		        .property("userProperties", new MapProperty()) //FIXME type
+		        .property("roles", new ArrayProperty(new RefProperty("#/definitions/RoleCreate")))
+		        .property("proficientLocales", new ArrayProperty(new ObjectProperty()))
+		        .property("secretQuestion", new StringProperty())
+		        
+		        .required("username").required("password").required("person");
 	}
 	
 	/**

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/HivDrugOrderSubclassHandler.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/HivDrugOrderSubclassHandler.java
@@ -10,6 +10,10 @@
 package org.openmrs.module.webservices.rest.web;
 
 import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Order;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -84,18 +88,37 @@ public class HivDrugOrderSubclassHandler extends BaseDelegatingSubclassHandler<O
 	}
 	
 	@Override
-	public Model getGETModel(Representation representation) {
-		return null;
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = new ModelImpl();
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+					.property("startDate", new DateProperty())
+					.property("autoExpireDate", new DateProperty())
+					.property("standardRegimenCode", new StringProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+					.property("patient", new RefProperty("#/definitions/PatientGetRef"))
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+					.property("patient", new RefProperty("#/definitions/PatientGet"))
+					.property("concept", new RefProperty("#/definitions/ConceptGet"));
+		}
+		return model;
 	}
 	
 	@Override
-	public Model getCREATEModel(Representation representation) {
-		return null;
-	}
-	
-	@Override
-	public Model getUPDATEModel(Representation representation) {
-		return null;
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+				.property("patient", new StringProperty().example("uuid"))
+				.property("concept", new StringProperty().example("uuid"))
+				.property("startDate", new DateProperty())
+				.property("autoExpireDate", new DateProperty())
+				.property("standardRegimenCode", new StringProperty())
+				.property("instructions", new StringProperty())
+
+				.required("patient").required("concept");
 	}
 	
 	/**

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/HivDrugOrderSubclassHandler.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/HivDrugOrderSubclassHandler.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web;
 
+import io.swagger.models.Model;
 import org.openmrs.Order;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
@@ -80,6 +81,21 @@ public class HivDrugOrderSubclassHandler extends BaseDelegatingSubclassHandler<O
 		d.addProperty("instructions");
 		return d;
 		
+	}
+	
+	@Override
+	public Model getGETModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
+		return null;
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeCrudResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeCrudResource1_9.java
@@ -12,6 +12,10 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 import java.util.Arrays;
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.attribute.Attribute;
 import org.openmrs.customdatatype.CustomDatatype;
@@ -102,6 +106,29 @@ public abstract class BaseAttributeCrudResource1_9<T extends Attribute<?, ?>, P,
 		description.addRequiredProperty("attributeType");
 		description.addRequiredProperty("value");
 		return description;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("attributeType", new StringProperty().example("uuid"))
+		        .property("value", new StringProperty())
+		        
+		        .required("attributeType").required("value");
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("display", new StringProperty())
+			        .property("uuid", new StringProperty())
+			        .property("attributeType", new StringProperty()) //FIXME type
+			        .property("value", new StringProperty()) //FIXME type
+			        .property("voided", new BooleanProperty());
+		}
+		return model;
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeTypeCrudResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeTypeCrudResource1_9.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.attribute.AttributeType;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
@@ -24,6 +28,38 @@ import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingC
  * @param <T>
  */
 public abstract class BaseAttributeTypeCrudResource1_9<T extends AttributeType<?>> extends MetadataDelegatingCrudResource<T> {
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("minOccurs", new IntegerProperty())
+			        .property("maxOccurs", new IntegerProperty())
+			        .property("datatypeClassname", new StringProperty())
+			        .property("preferredHandlerClassname", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("datatypeConfig", new StringProperty())
+			        .property("handlerConfig", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("datatypeClassname", new StringProperty())
+		        .property("minOccurs", new IntegerProperty())
+		        .property("maxOccurs", new IntegerProperty())
+		        .property("datatypeConfig", new StringProperty())
+		        .property("preferredHandlerClassname", new StringProperty())
+		        .property("handlerConfig", new StringProperty())
+		        
+		        .required("datatypeClassname");
+		
+	}
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapResource1_9.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.ConceptMap;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -51,6 +54,33 @@ public class ConceptMapResource1_9 extends ConceptMapResource1_8 {
 			return description;
 		}
 		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("conceptReferenceTerm", new RefProperty("#/definitions/ConceptreferencetermGetRef"))
+			        .property("conceptMapType", new RefProperty("#/definitions/ConceptmaptypeGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("conceptReferenceTerm", new RefProperty("#/definitions/ConceptreferencetermGet"))
+			        .property("conceptMapType", new RefProperty("#/definitions/ConceptmaptypeGet"));
+		}
+		model.getProperties().remove("source"); //FIXME check
+		model.getProperties().remove("sourceCode");
+		model.getProperties().remove("comment");
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return new ModelImpl()
+		        .property("conceptReferenceTerm", new RefProperty("#/definitions/ConceptreferencetermCreate"))
+		        .property("conceptMapType", new RefProperty("#/definitions/ConceptmaptypeCreate"))
+		        
+		        .required("conceptReferenceTerm").required("conceptMapType");
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapTypeResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapTypeResource1_9.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
 import org.openmrs.ConceptMapType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -77,6 +80,22 @@ public class ConceptMapTypeResource1_9 extends MetadataDelegatingCrudResource<Co
 		description.addProperty("isHidden");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("isHidden", new BooleanProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("isHidden", new BooleanProperty());
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptReferenceTermMap;
 import org.openmrs.api.context.Context;
@@ -82,6 +85,38 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 		description.addRequiredProperty("conceptMapType");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("termA", new RefProperty("#/definitions/ConceptreferencetermGetRef"))
+			        .property("termB", new RefProperty("#/definitions/ConceptreferencetermGetRef"))
+			        .property("conceptMapType", new RefProperty("#/definitions/ConceptmaptypeGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("termA", new RefProperty("#/definitions/ConceptreferencetermGet"))
+			        .property("termB", new RefProperty("#/definitions/ConceptreferencetermGet"))
+			        .property("conceptMapType", new RefProperty("#/definitions/ConceptmaptypeGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("termA", new RefProperty("#/definitions/ConceptreferencetermCreate"))
+		        .property("termB", new RefProperty("#/definitions/ConceptreferencetermCreate"))
+		        .property("conceptMapType", new RefProperty("#/definitions/ConceptmaptypeCreate"))
+		        
+		        .required("termA").required("termB").required("conceptMapType");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermResource1_9.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import com.sun.org.apache.xpath.internal.operations.Mod;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.api.ConceptService;
@@ -86,6 +91,41 @@ public class ConceptReferenceTermResource1_9 extends MetadataDelegatingCrudResou
 		description.addProperty("version");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("code", new StringProperty())
+			        .property("version", new StringProperty());
+			
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("conceptSource", new RefProperty("#/definitions/ConceptsourceGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("conceptSource", new RefProperty("#/definitions/ConceptsourceGet"));
+		}
+		return model;
+		
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("code", new StringProperty())
+		        .property("conceptSource", new StringProperty())
+		        .property("version", new StringProperty())
+		        
+		        .required("code").required("conceptSource");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl(); //FIXME missing props
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.ConceptClass;
 import org.openmrs.ConceptName;
 import org.openmrs.ConceptSearchResult;
@@ -33,6 +33,10 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * {@link org.openmrs.module.webservices.rest.web.annotation.Resource} for
@@ -66,6 +70,32 @@ public class ConceptSearchResource1_9 extends BaseDelegatingResource<ConceptSear
 		}
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("display", new StringProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("conceptName", new RefProperty("#/definitions/ConceptNameGetRef"));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("concept", new RefProperty("#/definitions/ConceptGet"))
+			        .property("conceptName", new RefProperty("#/definitions/ConceptNameGetRef"))
+			        .property("word", new StringProperty())
+			        .property("transientWeight", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return null;
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -79,6 +82,29 @@ public class ConceptStopwordResource1_9 extends DelegatingCrudResource<ConceptSt
 		description.addRequiredProperty("value");
 		description.addProperty("locale");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty());
+		
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("value", new StringProperty())
+			        .property("locale", new StringProperty().example("en")); //FIXME type
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("value", new StringProperty())
+		        .property("locale", new StringProperty().example("en"))
+		        
+		        .required("value");
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
@@ -9,9 +9,14 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.SubResource;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
@@ -35,6 +40,23 @@ public class CustomDatatypeHandlerResource1_9 extends DelegatingSubResource<Cust
 		return description;
 	}
 	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("handlerClassname", new StringProperty())
+			        .property("display", new StringProperty()); //FIXME delegate property name
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return null;
+	}
+
 	@Override
 	public CustomDatatypeHandlerRepresentation newDelegate() {
 		return new CustomDatatypeHandlerRepresentation();

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
@@ -9,9 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.customdatatype.CustomDatatypeHandler;
@@ -30,6 +32,9 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Resource(name = RestConstants.VERSION_1 + "/customdatatype", supportedClass = CustomDatatypeRepresentation.class, supportedOpenmrsVersions = {
         "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*" })
@@ -97,6 +102,30 @@ public class CustomDatatypeResource1_9 extends DelegatingCrudResource<CustomData
 		return null;
 	}
 	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("datatypeClassname", new StringProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("handlers", new ArrayProperty(new RefProperty("#/definitions/CustomdatatypeHandlersGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("handlers", new ArrayProperty(new RefProperty("#/definitions/CustomdatatypeHandlersGet")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return null;
+	}
+
 	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CustomDatatypeRepresentation> datatypes = getAllCustomDatatypes();

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterProviderResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterProviderResource1_9.java
@@ -9,6 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterProvider;
 import org.openmrs.EncounterRole;
@@ -83,6 +88,47 @@ public class EncounterProviderResource1_9 extends DelegatingSubResource<Encounte
 		description.addProperty("voided");
 		description.addProperty("voidReason");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("provider", new RefProperty("#/definitions/ProviderGetRef"))
+			        .property("encounterRole", new RefProperty("#/definitions/EncounterroleGetRef"))
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("provider", new RefProperty("#/definitions/ProviderGet"))
+			        .property("encounterRole", new RefProperty("#/definitions/EncounterroleGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("provider", new StringProperty().example("uuid"))
+		        .property("encounterRole", new StringProperty().example("uuid"))
+		        .property("encounter", new StringProperty()); //FIXME remove if not needed
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("provider", new RefProperty("#/definitions/ProviderCreate"))
+			        .property("encounter", new RefProperty("#/definitions/EncounterCreate"))
+			        .property("encounterRole", new RefProperty("#/definitions/EncounterroleCreate"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("encounterRole", new StringProperty())
+		        .property("voided", new BooleanProperty())
+		        .property("voidReason", new StringProperty());
 	}
 	
 	@Override

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
@@ -9,11 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
 import org.openmrs.EncounterRole;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
@@ -38,6 +40,21 @@ public class EncounterRoleResource1_9 extends MetadataDelegatingCrudResource<Enc
 		description.addRequiredProperty("description");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return super.getCREATEModel(rep);
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/FormResourceResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/FormResourceResource1_9.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Form;
 import org.openmrs.FormResource;
@@ -135,6 +139,43 @@ public class FormResourceResource1_9 extends DelegatingSubResource<FormResource,
 		description.addProperty("valueReference");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty());
+		
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("name", new StringProperty())
+			        .property("valueReference", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("dataType", new StringProperty())
+			        .property("handler", new StringProperty())
+			        .property("handlerConfig", new StringProperty());
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("form", new StringProperty())
+		        .property("name", new StringProperty())
+		        .property("dataType", new StringProperty())
+		        .property("handler", new StringProperty())
+		        .property("handlerConfig", new StringProperty())
+		        .property("value", new StringProperty())
+		        .property("valueReference", new StringProperty());
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("form", new RefProperty("#/definitions/FormCreate"));
+		}
+		return model;
 	}
 	
 	@Override

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9.java
@@ -9,6 +9,12 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Provider;
 import org.openmrs.ProviderAttribute;
 import org.openmrs.api.context.Context;
@@ -105,6 +111,45 @@ public class ProviderResource1_9 extends MetadataDelegatingCrudResource<Provider
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGetRef"))
+			        .property("identifier", new StringProperty())
+			        .property("attributes", new ArrayProperty(new RefProperty("#/definitions/ProviderAttributeGetRef")))
+			        .property("preferredHandlerClassname", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonGet"))
+			        .property("attributes", new ArrayProperty(new RefProperty("#/definitions/ProviderAttributeGet")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
+		        .property("person", new StringProperty().example("uuid"))
+		        .property("identifier", new StringProperty())
+		        .property("attributes", new ArrayProperty(new RefProperty("#/definitions/ProviderAttributeCreate")))
+		        .property("retired", new BooleanProperty())
+		        
+		        .required("person").required("identifier");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("person", new RefProperty("#/definitions/PersonCreate"));
+		}
+		return model;
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
@@ -11,6 +11,9 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
 import java.util.List;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.APIException;
@@ -105,6 +108,48 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 		DelegatingResourceDescription description = getCreatableProperties();
 		description.removeProperty("property");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("property", new StringProperty())
+			        .property("value", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("display", new StringProperty());
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("datatypeClassname", new StringProperty())
+			        .property("datatypeConfig", new StringProperty())
+			        .property("preferredHandlerClassname", new StringProperty())
+			        .property("handlerConfig", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("property", new StringProperty())
+		        .property("description", new StringProperty())
+		        .property("datatypeClassname", new StringProperty())
+		        .property("datatypeConfig", new StringProperty())
+		        .property("preferredHandlerClassname", new StringProperty())
+		        .property("handlerConfig", new StringProperty())
+		        .property("value", new StringProperty())
+		        
+		        .required("property");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		Model model = getCREATEModel(rep);
+		model.getProperties().remove("property");
+		return model;
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
@@ -9,6 +9,13 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
 import org.openmrs.VisitAttribute;
@@ -135,6 +142,72 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 		//shouldn't be editing the patient
 		description.removeProperty("patient");
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("startDatetime", new DateProperty())
+			        .property("stopDatetime", new DateProperty())
+			        .property("attributes", new ArrayProperty(new StringProperty())) //FIXME type
+			        .property("voided", new BooleanProperty());
+		}
+		if (rep instanceof DefaultRepresentation) {
+			modelImpl
+			        .property("patient", new RefProperty("#/definitions/PatientGetRef"))
+			        .property("visitType", new RefProperty("#/definitions/VisittypeGetRef"))
+			        .property("indication", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("location", new RefProperty("#/definitions/LocationGetRef"))
+			        .property("encounters", new ArrayProperty(new RefProperty("#/definitions/EncounterGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			modelImpl
+			        .property("patient", new RefProperty("#/definitions/PatientGet"))
+			        .property("visitType", new RefProperty("#/definitions/VisittypeGet"))
+			        .property("indication", new RefProperty("#/definitions/ConceptGet"))
+			        .property("location", new RefProperty("#/definitions/LocationGet"))
+			        .property("encounters", new ArrayProperty(new RefProperty("#/definitions/EncounterGet")));
+		}
+		return modelImpl;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl()
+		        .property("patient", new StringProperty().example("uuid"))
+		        .property("visitType", new StringProperty().example("uuid"))
+		        .property("startDatetime", new DateProperty())
+		        .property("location", new StringProperty().example("uuid"))
+		        .property("indication", new StringProperty())
+		        .property("stopDatetime", new DateProperty())
+		        .property("encounters", new ArrayProperty(new StringProperty().example("uuid")))
+		        .property("attributes", new ArrayProperty(new RefProperty("#/definitions/VisitAttributeCreate")))
+		        
+		        .required("patient").required("visitType");
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("patient", new RefProperty("#/definitions/PatientCreate"))
+			        .property("visitType", new RefProperty("#/definitions/VisittypeCreate"))
+			        .property("location", new RefProperty("#/definitions/LocationCreate"))
+			        .property("indication", new RefProperty("#/definitions/ConceptCreate"))
+			        .property("encounters", new ArrayProperty(new RefProperty("#/definitions/EncounterCreate")));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("visitType", new RefProperty("#/definitions/VisittypeCreate"))
+		        .property("startDatetime", new DateProperty())
+		        .property("location", new RefProperty("#/definitions/LocationCreate"))
+		        .property("indication", new RefProperty("#/definitions/ConceptCreate"))
+		        .property("stopDatetime", new DateProperty())
+		        .property("encounters", new ArrayProperty(new RefProperty("#/definitions/EncounterCreate")))
+		        .property("attributes", new ArrayProperty(new StringProperty())); //FIXME type
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitTypeResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitTypeResource1_9.java
@@ -12,11 +12,13 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.models.Model;
 import org.openmrs.VisitType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
@@ -41,6 +43,16 @@ public class VisitTypeResource1_9 extends MetadataDelegatingCrudResource<VisitTy
 		description.addProperty("description");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return super.getGETModel(rep);
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return super.getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9Test.java
@@ -15,7 +15,6 @@ import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_9;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.ProviderResource1_9;
 
 public class ProviderResource1_9Test extends BaseDelegatingResourceTest<ProviderResource1_9, Provider> {
 	

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/test/GenericChildResource.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/test/GenericChildResource.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.test;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -38,6 +41,24 @@ public class GenericChildResource extends DelegatingCrudResource<GenericChild> {
 		description.addProperty("value");
 		
 		return description;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("value", new StringProperty());
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("value", new StringProperty());
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl();
 	}
 	
 	@Override

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/PatientAllergyResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/PatientAllergyResource2_0.java
@@ -12,8 +12,14 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.openmrs.Allergies;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Allergy;
+import org.openmrs.Allergies;
 import org.openmrs.AllergyReaction;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
@@ -87,6 +93,47 @@ public class PatientAllergyResource2_0 extends DelegatingSubResource<Allergy, Pa
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
 		return getCreatableProperties();
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("display", new StringProperty())
+			        .property("uuid", new StringProperty())
+			        .property("allergen", new ObjectProperty()) //FIXME type
+			        .property("severity", new RefProperty("#/definitions/ConceptGetRef"))
+			        .property("comment", new StringProperty())
+			        .property("reactions", new ArrayProperty(new RefProperty("#/definitions/ConceptGetRef")))
+			        .property("patient", new RefProperty("#/definitions/PatientGetRef"));
+		}
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("severity", new RefProperty("#/definitions/ConceptGet"))
+			        .property("reactions", new ArrayProperty(new RefProperty("#/definitions/ConceptGet")))
+			        .property("patient", new RefProperty("#/definitions/PatientGet"));
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("allergen", new ObjectProperty()) //FIXME type
+		        .property("severity", new ObjectProperty()
+		                .property("uuid", new StringProperty()))
+		        .property("comment", new StringProperty())
+		        .property("reactions", new ArrayProperty(new ObjectProperty()
+		                .property("allergy", new ObjectProperty().property("uuid", new StringProperty()))
+		                .property("reaction", new ObjectProperty().property("uuid", new StringProperty()))))
+		        
+		        .required("allergen");
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
 	}
 	
 	/**

--- a/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortMembershipResource2_1.java
+++ b/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortMembershipResource2_1.java
@@ -11,6 +11,10 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_1;
 
 import java.util.ArrayList;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Cohort;
 import org.openmrs.CohortMembership;
 import org.openmrs.Patient;
@@ -91,6 +95,36 @@ public class CohortMembershipResource2_1 extends DelegatingSubResource<CohortMem
 		d.addProperty("startDate");
 		d.addProperty("endDate");
 		return d;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uuid", new StringProperty())
+			        .property("display", new StringProperty())
+			        .property("startDate", new DateProperty())
+			        .property("endDate", new DateProperty())
+			        .property("patientUuid", new StringProperty());
+		}
+		//FIXME missing props
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("patientUuid", new StringProperty())
+		        .property("startDate", new DateProperty())
+		        .property("endDate", new DateProperty());
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("startDate", new DateProperty())
+		        .property("endDate", new DateProperty());
 	}
 	
 	@PropertyGetter("display")

--- a/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortResource2_1.java
+++ b/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortResource2_1.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_1;
 
+import io.swagger.models.Model;
 import org.openmrs.Cohort;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -28,6 +29,13 @@ public class CohortResource2_1 extends CohortResource1_8 {
 	@Override
 	public String getResourceVersion() {
 		return RestConstants2_1.RESOURCE_VERSION;
+	}
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		Model model = super.getGETModel(rep);
+		model.getProperties().remove("memberIds");
+		return model;
 	}
 	
 	@Override

--- a/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ConceptSourceResource2_1.java
+++ b/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ConceptSourceResource2_1.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_1;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
+import org.apache.xpath.operations.Mod;
 import org.openmrs.ConceptSource;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -24,6 +28,22 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0.ConceptS
  */
 @Resource(name = RestConstants.VERSION_1 + "/conceptsource", supportedClass = ConceptSource.class, supportedOpenmrsVersions = { "2.1.*" })
 public class ConceptSourceResource2_1 extends ConceptSourceResource2_0 {
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+			        .property("uniqueId", new StringProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return ((ModelImpl) super.getCREATEModel(representation))
+		        .property("uniqueId", new StringProperty());
+	}
 	
 	/**
 	 * @see DelegatingCrudResource#getRepresentationDescription(Representation)

--- a/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1.java
+++ b/omod-2.1/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1.java
@@ -9,7 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_1;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 import org.openmrs.Obs;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -22,6 +26,24 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11.ObsReso
  */
 @Resource(name = RestConstants.VERSION_1 + "/obs", supportedClass = Obs.class, supportedOpenmrsVersions = { "2.1.*" })
 public class ObsResource2_1 extends ObsResource1_11 {
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		return ((ModelImpl) super.getGETModel(rep))
+		        .property("status", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(Obs.Status.class)))
+		        .property("interpretation", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(Obs.Interpretation.class)));
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return ((ModelImpl) super.getCREATEModel(rep))
+		        .property("status", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(Obs.Status.class)))
+		        .property("interpretation", new StringProperty()
+		                ._enum(SwaggerSpecificationCreator.getEnumsAsList(Obs.Interpretation.class)));
+	}
 	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {

--- a/omod-common/pom.xml
+++ b/omod-common/pom.xml
@@ -12,12 +12,12 @@
 
 	<dependencies>
 		<dependency>
-		      <groupId>org.apache.tomcat</groupId>
-		      <artifactId>jasper</artifactId>
-		      <version>6.0.18</version>
-		      <scope>provided</scope>
-	     </dependency>
-		
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>jasper</artifactId>
+			<version>6.0.18</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
@@ -29,8 +29,24 @@
 			<artifactId>evo-inflector</artifactId>
 			<version>1.2.1</version>
 		</dependency>
+
+		<dependency>
+			<groupId>io.swagger</groupId>
+			<artifactId>swagger-core</artifactId>
+			<version>1.5.13</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.validation</groupId>
+					<artifactId>validation-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<resources>
 			<resource>
@@ -72,7 +88,7 @@
 				</excludes>
 			</testResource>
 		</testResources>
-		
+
 		<plugins>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/core/property/EnumProperty.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/core/property/EnumProperty.java
@@ -1,0 +1,20 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.docs.swagger.core.property;
+
+import io.swagger.models.properties.StringProperty;
+import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
+
+public class EnumProperty extends StringProperty {
+	
+	public EnumProperty(Class<? extends Enum<?>> e) {
+		_enum(SwaggerSpecificationCreator.getEnumsAsList(e));
+	}
+}

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -23,6 +23,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -42,6 +47,8 @@ import org.openmrs.module.webservices.rest.web.annotation.RepHandler;
 import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.NamedRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -64,6 +71,34 @@ import org.openmrs.util.OpenmrsUtil;
 public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<T> implements Converter<T>, Resource, DelegatingResourceHandler<T> {
 	
 	private final Log log = LogFactory.getLog(getClass());
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = new ModelImpl();
+		if (rep instanceof DefaultRepresentation) {
+			model
+			        .property("links", new ArrayProperty()
+			                .items(new ObjectProperty()
+			                        .property("rel", new StringProperty().example("self|full"))
+			                        .property("uri", new StringProperty(StringProperty.Format.URI))));
+			
+		} else if (rep instanceof FullRepresentation) {
+			model
+			        .property("auditInfo", new StringProperty())
+			        .property("links", new ArrayProperty()
+			                .items(new ObjectProperty()
+			                        .property("rel", new StringProperty()).example("self")
+			                        .property("uri", new StringProperty(StringProperty.Format.URI))));
+			
+		} else if (rep instanceof RefRepresentation) {
+			model
+			        .property("links", new ArrayProperty()
+			                .items(new ObjectProperty()
+			                        .property("rel", new StringProperty().example("self"))
+			                        .property("uri", new StringProperty(StringProperty.Format.URI))));
+		}
+		return model;
+	}
 	
 	protected Set<String> propertiesIgnoredWhenUpdating = new HashSet<String>();
 	
@@ -266,6 +301,15 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 			description.getProperties().remove(property);
 		}
 		return description;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		ModelImpl model = (ModelImpl) getCREATEModel(rep);
+		for (String property : getPropertiesToExposeAsSubResources()) {
+			model.getProperties().remove(property);
+		}
+		return model;
 	}
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.resource.impl;
 
+import io.swagger.models.Model;
 import org.openmrs.OpenmrsData;
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.api.context.Context;
@@ -21,6 +22,7 @@ import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.RepHandler;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.api.Resource;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
@@ -74,7 +76,12 @@ public abstract class BaseDelegatingSubclassHandler<Superclass, Subclass extends
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		return getCreatableProperties();
 	}
-	
+
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		return getCREATEModel(rep);
+	}
+
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#save(java.lang.Object)
 	 */

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingResourceHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingResourceHandler.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.resource.impl;
 
+import io.swagger.models.Model;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -89,4 +90,38 @@ public interface DelegatingResourceHandler<T> extends DelegatingPropertyAccessor
 	 */
 	DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException;
 	
+	/**
+	 * Returns a {@link Model} object representing GET representation schema for the resource.
+	 * 
+	 * @param rep representation type under which the resource {@link Model} should be fetched. It
+	 *            can take {@link Representation#DEFAULT}, {@link Representation#REF}, or
+	 *            {@link Representation#FULL}
+	 * @return a {@link Model} object or null in case if such model does not exist or not
+	 *         documented.
+	 */
+	Model getGETModel(Representation rep);
+	
+	/**
+	 * Returns a {@link Model} object representing CREATE representation schema for the resource.
+	 * The returned model object will hold properties (and example values) required to create the
+	 * underlying resource.
+	 * 
+	 * @param rep representation type under which the resource {@link Model} should be fetched. It
+	 *            can take {@link Representation#DEFAULT}, or {@link Representation#FULL}
+	 * @return a {@link Model} object or null in case if such model does not exist or not
+	 *         documented.
+	 */
+	Model getCREATEModel(Representation rep);
+	
+	/**
+	 * Returns a {@link Model} object representing UPDATE representation schema for the resource.
+	 * The returned model object will hold properties (and example values) required to update the
+	 * underlying resource.
+	 * 
+	 * @param rep representation type under which the resource {@link Model} should be fetched. It
+	 *            can take {@link Representation#DEFAULT}, or {@link Representation#FULL}
+	 * @return a {@link Model} object or null in case if such model does not exist or not
+	 *         documented.
+	 */
+	Model getUPDATEModel(Representation rep);
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
@@ -11,6 +11,10 @@ package org.openmrs.module.webservices.rest.web.resource.impl;
 
 import java.util.Date;
 
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.api.context.Context;
@@ -33,6 +37,28 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
  * @param <T>
  */
 public abstract class MetadataDelegatingCrudResource<T extends OpenmrsMetadata> extends DelegatingCrudResource<T> {
+	
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
+		        .property("uuid", new StringProperty())
+		        .property("display", new StringProperty());
+		if (rep instanceof FullRepresentation) {
+			model
+			        .property("name", new StringProperty())
+			        .property("description", new StringProperty())
+			        .property("retired", new BooleanProperty());
+		}
+		return model;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return new ModelImpl()
+		        .property("name", new StringProperty())
+		        .property("description", new StringProperty())
+		        .required("name");
+	}
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingConverter#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalClassResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalClassResource_1_9.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.mockingbird.test.AnimalClass;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -31,7 +32,12 @@ public class AnimalClassResource_1_9 extends DelegatingSubResource<AnimalClass, 
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
 		return null;
 	}
-	
+
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+
 	@Override
 	public Animal getParent(AnimalClass instance) {
 		return null;

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalResource_1_9.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -59,7 +60,12 @@ public class AnimalResource_1_9 extends DelegatingCrudResource<Animal> {
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
 		return null;
 	}
-	
+
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+
 	/**
 	 * @see DelegatingCrudResource#getByUniqueId(String)
 	 */

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/BirdResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/BirdResource_1_9.java
@@ -62,20 +62,10 @@ public class BirdResource_1_9 extends DelegatingCrudResource<Bird> {
 	}
 	
 	@Override
-	public Model getGETModel(Representation representation) {
+	public Model getCREATEModel(Representation rep) {
 		return null;
 	}
-	
-	@Override
-	public Model getCREATEModel(Representation representation) {
-		return null;
-	}
-	
-	@Override
-	public Model getUPDATEModel(Representation representation) {
-		return null;
-	}
-	
+
 	/**
 	 * @see DelegatingCrudResource#getByUniqueId(String)
 	 */

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/BirdResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/BirdResource_1_9.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Bird;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -57,6 +58,21 @@ public class BirdResource_1_9 extends DelegatingCrudResource<Bird> {
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/CatSubclassHandler_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/CatSubclassHandler_1_9.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.mockingbird.test.Cat;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -86,6 +87,21 @@ public class CatSubclassHandler_1_9 implements DelegatingSubclassHandler<Animal,
 	
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
+		return null;
+	}
+	
+	@Override
+	public Model getGETModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+	
+	@Override
+	public Model getUPDATEModel(Representation representation) {
 		return null;
 	}
 }

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAndOrderAnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAndOrderAnimalResource_1_9.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -57,6 +58,11 @@ public class DuplicateNameAndOrderAnimalResource_1_9 extends DelegatingCrudResou
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		return null;
+	}
+
+	@Override
+	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAnimalResource_1_9.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -57,6 +58,11 @@ public class DuplicateNameAnimalResource_1_9 extends DelegatingCrudResource<Anim
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		return null;
+	}
+
+	@Override
+	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/InstantiateExceptionAnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/InstantiateExceptionAnimalResource_1_9.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -61,6 +62,11 @@ public class InstantiateExceptionAnimalResource_1_9 extends DelegatingCrudResour
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		return null;
+	}
+
+	@Override
+	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/UnannotatedAnimalResource.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/UnannotatedAnimalResource.java
@@ -9,6 +9,7 @@
  */
 package org.mockingbird.test.rest.resource;
 
+import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -57,7 +58,12 @@ public class UnannotatedAnimalResource extends DelegatingCrudResource<Animal> {
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
 		return null;
 	}
-	
+
+	@Override
+	public Model getCREATEModel(Representation representation) {
+		return null;
+	}
+
 	/**
 	 * @see DelegatingCrudResource#getByUniqueId(String)
 	 */

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResourceTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResourceTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.resource.impl;
 
+import io.swagger.models.Model;
 import org.junit.Test;
 import org.openmrs.Location;
 import org.openmrs.api.context.ServiceContext;
@@ -98,6 +99,21 @@ public class MetadataDelegatingCrudResourceTest {
 		
 		@Override
 		public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+			return null;
+		}
+		
+		@Override
+		public Model getGETModel(Representation representation) {
+			return null;
+		}
+		
+		@Override
+		public Model getCREATEModel(Representation representation) {
+			return null;
+		}
+		
+		@Override
+		public Model getUPDATEModel(Representation representation) {
 			return null;
 		}
 	}


### PR DESCRIPTION
- adds swagger-core library
  * uses its Java API and model classes to construct and generate the swagger json.
- introudce new methods which model objects used in constructing the definitions section:
  * getGETModel(Representation) :  returns a object represting GET representation schema of resource
  * getCREATEModel(Representation) : returns a object representing CREATE representation shema of a resource
  * getUPDATEModel(Representation) : returns a object representing POST Update representation schema of a resource

ex: PersonGet, PersonCreate, PersonUpdate
- adds new test cases to: SwaggerSpecificationCreatorTest.java

- adds support for multiple representation types
GET schemas have support for representations: DEFAULT, REF, and FULL
CREATE schemas have support for representations: DEFAULT, and FULL
POST_UPDATE schemas have support for representations: DEFAULT

  * uses default schema for the shema of responses and parameters

Swagger before: http://www.jsoneditoronline.org/?id=6ac2d0c797f5e8e4060d09b62b300b04
Swagger after: http://jsoneditoronline.org/?id=d692754b9b4543f7388572317dc10400