### PR TITLE
Bug when retrieving non-active(soft deleted) patient identifiers

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
@@ -33,6 +33,8 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * Sub-resource for patient identifiers
@@ -248,7 +250,13 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 	 */
 	@Override
 	public NeedsPaging<PatientIdentifier> doGetAll(Patient parent, RequestContext context) throws ResponseException {
-		return new NeedsPaging<PatientIdentifier>(parent.getActiveIdentifiers(), context);
+		List<PatientIdentifier> patientIdentifiers;
+		if (context.getIncludeAll()) {
+			patientIdentifiers = new ArrayList<PatientIdentifier>(parent.getIdentifiers());
+		} else {
+			patientIdentifiers = parent.getActiveIdentifiers();
+		}
+		return new NeedsPaging<PatientIdentifier>(patientIdentifiers, context);
 	}
 	
 	/**

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PatientIdentifierController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PatientIdentifierController1_9Test.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotEquals;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -122,6 +123,23 @@ public class PatientIdentifierController1_9Test extends MainResourceControllerTe
 		handle(req);
 		assertEquals(true, service.getPatientIdentifierByUuid(getUuid()).isVoided());
 		assertEquals(reason, service.getPatientIdentifierByUuid(getUuid()).getVoidReason());
+	}
+	
+	@Test
+	public void shouldListAllPatientIdentifiersWithVoidedIdentifiersForAPatient() throws Exception {
+		assertEquals(false, service.getPatientIdentifierByUuid(getUuid()).isVoided());
+		MockHttpServletRequest req = request(RequestMethod.DELETE, getURI() + "/" + getUuid());
+		final String reason = "none";
+		req.addParameter("reason", reason);
+		handle(req);
+		assertEquals(true, service.getPatientIdentifierByUuid(getUuid()).isVoided());
+		SimpleObject result = deserialize(handle(newGetRequest(getURI(), new Parameter(
+		        RestConstants.REQUEST_PROPERTY_FOR_INCLUDE_ALL, "true"))));
+		assertNotEquals(getAllCount(), Util.getResultsSize(result));
+		
+		SimpleObject nextResult = deserialize(handle(newGetRequest(getURI(), new Parameter(
+		        RestConstants.REQUEST_PROPERTY_FOR_INCLUDE_ALL, "false"))));
+		assertEquals(getAllCount(), Util.getResultsSize(nextResult));
 	}
 	
 	@Test


### PR DESCRIPTION
# JIRA TICKET NAME:
RESTWS-675: [Fix inability to retrieve soft deleted patient identifiers](https://issues.openmrs.org/browse/RESTWS-675)

## SUMMARY:
This PR fixes Bug when retrieving non-active(soft deleted) patient identifiers