### PR TITLE
RESTWS-562 - Make getCREATEModel(Rep) method optional

### DIFF
--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderableResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderableResource1_10.java
@@ -186,11 +186,6 @@ public class OrderableResource1_10 extends BaseDelegatingResource<ConceptSearchR
 		return description;
 	}
 	
-	@Override
-	public Model getCREATEModel(Representation rep) {
-		return null;
-	}
-	
 	@PropertyGetter("display")
 	public String getDisplayString(ConceptSearchResult csr) {
 		ConceptName cn = csr.getConcept().getName();

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
@@ -134,11 +134,6 @@ public class ModuleResource1_8 extends BaseDelegatingReadableResource<Module> im
 		return model;
 	}
 	
-	@Override
-	public Model getCREATEModel(Representation rep) {
-		return null;
-	}
-	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#doGetAll(org.openmrs.module.webservices.rest.web.RequestContext)
 	 */

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
@@ -181,11 +181,6 @@ public class TaskActionResource1_8 extends BaseDelegatingResource<TaskAction> im
 		return description;
 	}
 	
-	@Override
-	public Model getCREATEModel(Representation rep) {
-		return null;
-	}
-	
 	/**
 	 * Converter does not handle getters starting with 'is' instead of 'get'
 	 */

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
@@ -93,11 +93,6 @@ public class ConceptSearchResource1_9 extends BaseDelegatingResource<ConceptSear
 		return model;
 	}
 	
-	@Override
-	public Model getCREATEModel(Representation rep) {
-		return null;
-	}
-	
 	/**
 	 * @see
 	 */

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
@@ -53,11 +53,6 @@ public class CustomDatatypeHandlerResource1_9 extends DelegatingSubResource<Cust
 	}
 	
 	@Override
-	public Model getCREATEModel(Representation rep) {
-		return null;
-	}
-	
-	@Override
 	public CustomDatatypeHandlerRepresentation newDelegate() {
 		return new CustomDatatypeHandlerRepresentation();
 	}

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
@@ -122,11 +122,6 @@ public class CustomDatatypeResource1_9 extends DelegatingCrudResource<CustomData
 	}
 	
 	@Override
-	public Model getCREATEModel(Representation rep) {
-		return null;
-	}
-	
-	@Override
 	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
 		List<CustomDatatypeRepresentation> datatypes = getAllCustomDatatypes();
 		

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -285,6 +285,11 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		throw new ResourceDoesNotSupportOperationException();
 	}
 	
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		return null;
+	}
+	
 	/**
 	 * Gets a description of resource's properties which can be edited.
 	 * <p/>

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalClassResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalClassResource_1_9.java
@@ -9,7 +9,6 @@
  */
 package org.mockingbird.test.rest.resource;
 
-import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.mockingbird.test.AnimalClass;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -30,11 +29,6 @@ public class AnimalClassResource_1_9 extends DelegatingSubResource<AnimalClass, 
 	
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		return null;
-	}
-	
-	@Override
-	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/AnimalResource_1_9.java
@@ -9,7 +9,6 @@
  */
 package org.mockingbird.test.rest.resource;
 
-import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -58,11 +57,6 @@ public class AnimalResource_1_9 extends DelegatingCrudResource<Animal> {
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		return null;
-	}
-	
-	@Override
-	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/BirdResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/BirdResource_1_9.java
@@ -9,7 +9,6 @@
  */
 package org.mockingbird.test.rest.resource;
 
-import io.swagger.models.Model;
 import org.mockingbird.test.Bird;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -58,11 +57,6 @@ public class BirdResource_1_9 extends DelegatingCrudResource<Bird> {
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		return null;
-	}
-	
-	@Override
-	public Model getCREATEModel(Representation rep) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAndOrderAnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAndOrderAnimalResource_1_9.java
@@ -9,7 +9,6 @@
  */
 package org.mockingbird.test.rest.resource;
 
-import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -58,11 +57,6 @@ public class DuplicateNameAndOrderAnimalResource_1_9 extends DelegatingCrudResou
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		return null;
-	}
-	
-	@Override
-	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/DuplicateNameAnimalResource_1_9.java
@@ -9,7 +9,6 @@
  */
 package org.mockingbird.test.rest.resource;
 
-import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -58,11 +57,6 @@ public class DuplicateNameAnimalResource_1_9 extends DelegatingCrudResource<Anim
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		return null;
-	}
-	
-	@Override
-	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/InstantiateExceptionAnimalResource_1_9.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/InstantiateExceptionAnimalResource_1_9.java
@@ -9,7 +9,6 @@
  */
 package org.mockingbird.test.rest.resource;
 
-import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -62,11 +61,6 @@ public class InstantiateExceptionAnimalResource_1_9 extends DelegatingCrudResour
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		return null;
-	}
-	
-	@Override
-	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	

--- a/omod-common/src/test/java/org/mockingbird/test/rest/resource/UnannotatedAnimalResource.java
+++ b/omod-common/src/test/java/org/mockingbird/test/rest/resource/UnannotatedAnimalResource.java
@@ -9,7 +9,6 @@
  */
 package org.mockingbird.test.rest.resource;
 
-import io.swagger.models.Model;
 import org.mockingbird.test.Animal;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -56,11 +55,6 @@ public class UnannotatedAnimalResource extends DelegatingCrudResource<Animal> {
 	 */
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-		return null;
-	}
-	
-	@Override
-	public Model getCREATEModel(Representation representation) {
 		return null;
 	}
 	


### PR DESCRIPTION
Make `Model getCREATEModel(Representation rep)` optional, to avoid having to implement empty methods that returns just null, for resources that do not support CREATE operation and for test resources and the like.

Issue: https://issues.openmrs.org/browse/RESTWS-562