### PR TITLE
RESTWS-649 Update

### DIFF
--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/controller/SwaggerSpecificationController.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/controller/SwaggerSpecificationController.java
@@ -27,10 +27,17 @@ public class SwaggerSpecificationController {
 	public @ResponseBody
 	String getSwaggerSpecification(HttpServletRequest request) throws Exception {
 		
+		String host = request.getHeader(HttpHeaders.HOST);
+		
+		String scheme = request.getHeader(HttpHeaders.X_FORWARDED_PROTO);
+		if (scheme == null) {
+			scheme = request.getScheme();
+		}
+		
 		return new SwaggerSpecificationCreator()
-		        .host(request.getHeader(HttpHeaders.HOST))
+		        .host(host)
 		        .basePath(request.getContextPath() + "/ws/rest/v1")
-		        .scheme(Scheme.forValue(request.getScheme()))
+		        .scheme(Scheme.forValue(scheme))
 		        
 		        .BuildJSON();
 	}


### PR DESCRIPTION
Change to get original host and the port values of the running server.

Talk thread: https://talk.openmrs.org/t/how-to-get-server-details-from-httpservletrequest/13554

Issue: [RESTWS-649](https://issues.openmrs.org/browse/RESTWS-649)