### PR TITLE
RESTWS-560 Change extrenalDocs url to permanent link

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SwaggerSpecificationCreator.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SwaggerSpecificationCreator.java
@@ -224,7 +224,7 @@ public class SwaggerSpecificationCreator {
 		        .produces("application/json")
 		        .externalDocs(new ExternalDocs()
 		                .description("Find more info on REST Module Wiki")
-		                .url("https://wiki.openmrs.org/display/docs/REST+Module"));
+		                .url("https://wiki.openmrs.org/x/xoAaAQ"));
 	}
 	
 	private List<ModuleVersion> getModuleVersions() {


### PR DESCRIPTION
Use the permanent link to the wiki page:
https://wiki.openmrs.org/x/xoAaAQ

As the title-based URL could break if the page is moved or renamed in the future.

Sub-PR for: https://issues.openmrs.org/browse/RESTWS-560