### PR TITLE
PDMO-65: fix bug to enable retrieving soft deleted observations.

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -484,7 +484,8 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 			    Encounter.class)).getByUniqueId(encounterUuid);
 			if (enc == null)
 				return new EmptySearchResult();
-			List<Obs> obs = new ArrayList<Obs>(enc.getAllObs());
+			
+			List<Obs> obs = new ArrayList<Obs>(enc.getAllObs(context.getIncludeAll()));
 			return new NeedsPaging<Obs>(obs, context);
 		}
 		


### PR DESCRIPTION
# JIRA TICKET NAME:

PDMO-65: [Enable retrieving soft deleted observations](https://issues.openmrs.org/browse/PDMO-65)

# SUMMARY:

Fix bug in the webservice to enable retrieving soft deleted  observations.