### PR TITLE
RESTWS-688: Enable installation of modules through rest calls

### DIFF
--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ModuleActionController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ModuleActionController1_8Test.java
@@ -13,17 +13,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.module.Module;
 import org.openmrs.module.webservices.helper.ModuleAction;
-import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.MockModuleFactoryWrapper;
 import org.openmrs.module.webservices.rest.web.RestConstants;
-import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.response.IllegalRequestException;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.ModuleActionResource1_8;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.ModuleResource1_8;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.Arrays;
 
@@ -35,7 +32,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.collection.IsEmptyCollection.emptyCollectionOf;
 import static org.hamcrest.core.IsNot.not;
 
-public class ModuleActionController1_8Tests extends MainResourceControllerTest {
+public class ModuleActionController1_8Test extends MainResourceControllerTest {
 	
 	@Autowired
 	RestService restService;
@@ -62,6 +59,21 @@ public class ModuleActionController1_8Tests extends MainResourceControllerTest {
 		
 		ModuleResource1_8 moduleResource = (ModuleResource1_8) restService.getResourceBySupportedClass(Module.class);
 		moduleResource.setModuleFactoryWrapper(mockModuleFactory);
+	}
+	
+	@Test
+	public void shouldInstallModule() throws Exception {
+		mockModuleFactory.loadModuleMock = mockModuleToLoad;
+		deserialize(handle(newPostRequest(getURI(), "{\"action\":\"install\", \"modules\":[\""
+		        + getUuid() + "\"], \"installUri\":\"" + getInstallUri() + "\"}")));
+		assertThat(mockModuleFactory.loadedModules, hasItem(mockModuleToLoad));
+		assertThat(mockModuleFactory.startedModules, hasItem(mockModuleToLoad));
+	}
+	
+	@Test(expected = IllegalRequestException.class)
+	public void shouldThrowErrorOnPoorUri() throws Exception {
+		deserialize(handle(newPostRequest(getURI(), "{\"action\":\"install\", \"modules\":[\""
+		        + getUuid() + "\"], \"installUri\":\"anystring\"}")));
 	}
 	
 	@Test
@@ -196,11 +208,15 @@ public class ModuleActionController1_8Tests extends MainResourceControllerTest {
 	
 	@Override
 	public String getUuid() {
-		return null;
+		return "atlas";
 	}
 	
 	@Override
 	public long getAllCount() {
 		return 0;
+	}
+	
+	public String getInstallUri() {
+		return "https://dl.bintray.com/openmrs/omod/xforms-4.3.11.omod";
 	}
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/helper/ModuleAction.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/helper/ModuleAction.java
@@ -17,13 +17,13 @@ import java.util.List;
 public class ModuleAction {
 	
 	public enum Action {
-		START, STOP, RESTART, UNLOAD;
+		START, STOP, RESTART, UNLOAD, INSTALL;
 	}
 	
 	public ModuleAction() {
 	}
 	
-	public ModuleAction(Action action, List<Module> modules, boolean startAll) {
+	public ModuleAction(Action action, List<Module> modules, boolean startAll, String installUri) {
 		this.modules = modules;
 		this.action = action;
 		this.allModules = startAll;
@@ -34,6 +34,8 @@ public class ModuleAction {
 	private Action action;
 	
 	private Boolean allModules;
+	
+	private String installUri;
 	
 	public void setModules(List<Module> modules) {
 		this.modules = modules;
@@ -57,5 +59,13 @@ public class ModuleAction {
 	
 	public void setAllModules(Boolean allModules) {
 		this.allModules = allModules;
+	}
+	
+	public void setInstallUri(String installUri) {
+		this.installUri = installUri;
+	}
+	
+	public String getInstallUri() {
+		return installUri;
 	}
 }


### PR DESCRIPTION
## JIRA TICKET NAME:

[RESTWS-688: Enable installation of modules through rest calls](https://issues.openmrs.org/browse/RESTWS-688)

## SUMMARY:
Currently a module could not be installed through a REST call. When a REST call is made the module is to be downloaded on to the server, loaded and started.