### PR TITLE
RESTWS-382 Add Access-Control-Allow-Origin in response headers

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/filter/RequestFilter.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/filter/RequestFilter.java
@@ -1,0 +1,45 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.filter;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Generic request filter intended for all /ws/rest calls <br/>
+ */
+public class RequestFilter implements Filter {
+	
+	protected final Log log = LogFactory.getLog(getClass());
+	
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		log.debug("Initializing REST WS generic request filter");
+	}
+	
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+	        throws IOException, ServletException {
+		HttpServletResponse response = (HttpServletResponse) servletResponse;
+		response.addHeader("Access-Control-Allow-Origin", "*");
+		
+		// continue with the filter chain in all circumstances
+		filterChain.doFilter(servletRequest, response);
+	}
+	
+	@Override
+	public void destroy() {
+		log.debug("Destroying REST WS generic request filter");
+	}
+}

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/filter/RequestFilterTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/filter/RequestFilterTest.java
@@ -1,0 +1,43 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.filter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.RestControllerTestUtils;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class RequestFilterTest extends RestControllerTestUtils {
+	
+	@Before
+	public void setUp() {
+	}
+	
+	@Test
+	public void testCORS() throws Exception {
+		String uri = getURI() + "/" + getUuid();
+		MockHttpServletResponse response = handle(newGetRequest(uri));
+		Assert.assertTrue(response.containsHeader("Access-Control-Allow-Origin"));
+	}
+	
+	public String getURI() {
+		return "user";
+	}
+	
+	public String getUuid() {
+		return Context.getAuthenticatedUser().getUuid();
+	}
+	
+	public long getAllCount() {
+		return 1;
+	}
+}


### PR DESCRIPTION
Issue: [RESTWS-382](https://issues.openmrs.org/browse/RESTWS-382)

Since we have authentication in place it is should be okay for the browsers to be able to make cross-origin requests to the API. APIs such as Jira, and GitHub does this.

The test I added here in webserveices.rest-omod-common fails when calling `handle(newGetRequest(uri));`. I think I've missed some initial configuration that requires for this test. Please have a look. I'll fix it in the next commit.