### PR TITLE
RESTWS-707: Fix bug in encounterRole endpoint

### DIFF
--- a/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/EncounterRoleResource1_11.java
+++ b/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/EncounterRoleResource1_11.java
@@ -1,0 +1,35 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11;
+
+import org.openmrs.EncounterRole;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.EncounterRoleResource1_9;
+
+/**
+ * {@link Resource} for {@link EncounterRole}, supporting standard CRUD operations
+ */
+@Resource(name = RestConstants.VERSION_1 + "/encounterrole", supportedClass = EncounterRole.class, supportedOpenmrsVersions = {
+        "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*" })
+public class EncounterRoleResource1_11 extends EncounterRoleResource1_9 {
+	
+	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#doSearch(org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	protected NeedsPaging<EncounterRole> doSearch(RequestContext context) {
+		return new NeedsPaging<EncounterRole>(Context.getEncounterService().getEncounterRolesByName(
+		    context.getParameter("q")), context);
+	}
+}

--- a/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/RestTestConstants1_11.java
+++ b/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/RestTestConstants1_11.java
@@ -12,4 +12,6 @@ package org.openmrs.module.webservices.rest.web;
 public class RestTestConstants1_11 {
 	
 	public static final String DRUG_UUID = "05ec820a-d297-44e3-be6e-698531d9dd3f";
+	
+	public static final String ENCOUNTER_ROLE_UUID = "a0b03050-c99b-11e0-9572-0800200c9a66";
 }

--- a/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_11/EncounterRoleController1_11Test.java
+++ b/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_11/EncounterRoleController1_11Test.java
@@ -1,0 +1,56 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_11;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.EncounterRole;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.test.Util;
+import org.openmrs.module.webservices.rest.web.RestTestConstants1_11;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+public class EncounterRoleController1_11Test extends MainResourceControllerTest {
+	
+	@Override
+	public String getURI() {
+		return "encounterrole";
+	}
+	
+	@Override
+	public String getUuid() {
+		return RestTestConstants1_11.ENCOUNTER_ROLE_UUID;
+	}
+	
+	@Override
+	public long getAllCount() {
+		return 1;
+	}
+	
+	@Test
+	public void shouldGetAnEncounterRoleByName() throws Exception {
+		final String ROLE_NAME = "Unknown";
+		
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+		req.setParameter("q", ROLE_NAME);
+		req.setParameter("v", "default");
+		SimpleObject result = deserialize(handle(req));
+		Object encounterRoleObject = Util.getResultsList(result).get(0);
+		
+		EncounterRole encounterRole = Context.getEncounterService().getEncounterRoleByName(ROLE_NAME);
+		Assert.assertEquals(encounterRole.getUuid(), PropertyUtils.getProperty(encounterRoleObject, "uuid"));
+		Assert.assertEquals(encounterRole.getName(), PropertyUtils.getProperty(encounterRoleObject, "name"));
+		Assert.assertEquals(encounterRole.getDescription(), PropertyUtils.getProperty(encounterRoleObject, "description"));
+	}
+}

--- a/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/EncounterRoleResource1_11Test.java
+++ b/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/EncounterRoleResource1_11Test.java
@@ -1,0 +1,54 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11;
+
+import org.openmrs.EncounterRole;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RestTestConstants1_11;
+import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
+
+public class EncounterRoleResource1_11Test extends BaseDelegatingResourceTest<EncounterRoleResource1_11, EncounterRole> {
+	
+	@Override
+	public EncounterRole newObject() {
+		return Context.getEncounterService().getEncounterRoleByUuid(getUuidProperty());
+	}
+	
+	@Override
+	public void validateDefaultRepresentation() throws Exception {
+		super.validateDefaultRepresentation();
+		assertPropEquals("display", getDisplayProperty());
+		getObject().toString();
+		assertPropEquals("uuid", getObject().getUuid());
+		assertPropPresent("links");
+	}
+	
+	@Override
+	public void validateFullRepresentation() throws Exception {
+		super.validateFullRepresentation();
+		assertPropEquals("description", getObject().getDescription());
+		assertPropEquals("dateCreated", getObject().getDateChanged());
+		assertPropEquals("retired", getObject().getRetired());
+		assertPropEquals("name", getObject().getName());
+		assertPropPresent("auditInfo");
+		assertPropPresent("retired");
+		assertPropPresent("resourceVersion");
+	}
+	
+	@Override
+	public String getDisplayProperty() {
+		return "Unknown";
+	}
+	
+	@Override
+	public String getUuidProperty() {
+		return RestTestConstants1_11.ENCOUNTER_ROLE_UUID;
+	}
+}

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
@@ -26,7 +26,7 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
  * {@link Resource} for {@link EncounterRole}, supporting standard CRUD operations
  */
 @Resource(name = RestConstants.VERSION_1 + "/encounterrole", supportedClass = EncounterRole.class, supportedOpenmrsVersions = {
-        "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*" })
+        "1.9.*", "1.10.*" })
 public class EncounterRoleResource1_9 extends MetadataDelegatingCrudResource<EncounterRole> {
 	
 	/**


### PR DESCRIPTION
Fix bug with `encounterRole` endpoint causing empty set `[ ]` to be returned when a query paramter in provider in API call
e.g `v1/encounterRole?q=unknown`

Issue: [RESTWS-707](https://issues.openmrs.org/browse/RESTWS-707)