### PR TITLE
RESTWS-721: Fix modules producing ref errors due to swagger exclusion

### DIFF
--- a/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/UnrelatedGenericChild.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/UnrelatedGenericChild.java
@@ -1,7 +1,16 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.unrelatedtest;
 
 import org.openmrs.module.webservices.rest.web.v1_0.test.GenericChild;
 
 public class UnrelatedGenericChild extends GenericChild {
-
+	
 }

--- a/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/UnrelatedGenericChild.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/UnrelatedGenericChild.java
@@ -1,0 +1,7 @@
+package org.openmrs.module.unrelatedtest;
+
+import org.openmrs.module.webservices.rest.web.v1_0.test.GenericChild;
+
+public class UnrelatedGenericChild extends GenericChild {
+
+}

--- a/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/rest/resource/UnrelatedGenericChildResource.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/rest/resource/UnrelatedGenericChildResource.java
@@ -1,0 +1,53 @@
+package org.openmrs.module.unrelatedtest.rest.resource;
+
+import io.swagger.models.Model;
+import org.openmrs.module.unrelatedtest.UnrelatedGenericChild;
+import org.openmrs.module.webservices.rest.doc.SwaggerSpecificationCreatorTest;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.v1_0.test.GenericChildResource;
+
+/**
+ * A test resource that is unrelated to the main webservices package.
+ *
+ * @see SwaggerSpecificationCreatorTest#testUnrelatedResourceDefinitions()
+ */
+@Resource(name = RestConstants.VERSION_1 + "/unrelated",
+		supportedClass = UnrelatedGenericChild.class, supportedOpenmrsVersions = {
+		"1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*" })
+public class UnrelatedGenericChildResource extends GenericChildResource {
+
+	public static boolean getGETCalled = false;
+
+	public static boolean getCREATECalled = false;
+
+	public static boolean getUPDATECalled = false;
+
+	/*******************************
+	 * TEST METHOD IMPLEMENTATIONS *
+	 *******************************
+	 *
+	 * These methods are the ones we want to test against. There implementaion is unimportant, they just set flags so we can
+	 * assert the methods were called correctly by the reflector.
+	 *
+	 */
+
+	@Override
+	public Model getGETModel(Representation rep) {
+		getGETCalled = true;
+		return super.getGETModel(rep);
+	}
+
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		getCREATECalled = true;
+		return super.getCREATEModel(rep);
+	}
+
+	@Override
+	public Model getUPDATEModel(Representation rep) {
+		getUPDATECalled = true;
+		return super.getUPDATEModel(rep);
+	}
+}

--- a/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/rest/resource/UnrelatedGenericChildResource.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/unrelatedtest/rest/resource/UnrelatedGenericChildResource.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.unrelatedtest.rest.resource;
 
 import io.swagger.models.Model;
@@ -10,41 +19,38 @@ import org.openmrs.module.webservices.rest.web.v1_0.test.GenericChildResource;
 
 /**
  * A test resource that is unrelated to the main webservices package.
- *
+ * 
  * @see SwaggerSpecificationCreatorTest#testUnrelatedResourceDefinitions()
  */
 @Resource(name = RestConstants.VERSION_1 + "/unrelated",
-		supportedClass = UnrelatedGenericChild.class, supportedOpenmrsVersions = {
-		"1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*" })
+        supportedClass = UnrelatedGenericChild.class, supportedOpenmrsVersions = {
+                "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*" })
 public class UnrelatedGenericChildResource extends GenericChildResource {
-
+	
 	public static boolean getGETCalled = false;
-
+	
 	public static boolean getCREATECalled = false;
-
+	
 	public static boolean getUPDATECalled = false;
-
+	
 	/*******************************
-	 * TEST METHOD IMPLEMENTATIONS *
-	 *******************************
-	 *
-	 * These methods are the ones we want to test against. There implementaion is unimportant, they just set flags so we can
-	 * assert the methods were called correctly by the reflector.
-	 *
+	 * TEST METHOD IMPLEMENTATIONS * These methods are the ones we want to test against. There
+	 * implementaion is unimportant, they just set flags so we can assert the methods were called
+	 * correctly by the reflector.
 	 */
-
+	
 	@Override
 	public Model getGETModel(Representation rep) {
 		getGETCalled = true;
 		return super.getGETModel(rep);
 	}
-
+	
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		getCREATECalled = true;
 		return super.getCREATEModel(rep);
 	}
-
+	
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		getUPDATECalled = true;

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/doc/SwaggerSpecificationCreatorTest.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/doc/SwaggerSpecificationCreatorTest.java
@@ -143,7 +143,7 @@ public class SwaggerSpecificationCreatorTest extends BaseModuleWebContextSensiti
 		Assert.assertTrue("Ensure that no data was added or removed from any tables",
 		    ensureCountsEqual(beforeCounts, afterCounts));
 	}
-	
+
 	private boolean ensureCountsEqual(Map<String, Integer> beforeCounts, Map<String, Integer> afterCounts) {
 		for (String key : beforeCounts.keySet()) {
 			if (beforeCounts.get(key) != afterCounts.get(key)) {

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/doc/SwaggerSpecificationCreatorTest.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/doc/SwaggerSpecificationCreatorTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.unrelatedtest.rest.resource.UnrelatedGenericChildResource;
 import org.openmrs.module.webservices.docs.swagger.SwaggerSpecificationCreator;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.api.RestService;
@@ -268,5 +269,31 @@ public class SwaggerSpecificationCreatorTest extends BaseModuleWebContextSensiti
 		assertFalse(json.contains("SystemsettingSubdetailsGet"));
 		assertFalse(json.contains("SystemsettingSubdetailsUpdate"));
 		assertTrue(json.contains("SystemsettingSubdetailsCreate"));
+	}
+
+	/**
+	 * Ensure that resources not directly related to the webservices.rest package are successfully defined in the swagger
+	 * documentation.
+	 */
+	@Test
+	public void testUnrelatedResourceDefinitions() {
+		// check the statics are false first
+		assertFalse(UnrelatedGenericChildResource.getGETCalled);
+		assertFalse(UnrelatedGenericChildResource.getCREATECalled);
+		assertFalse(UnrelatedGenericChildResource.getUPDATECalled);
+
+		SwaggerSpecificationCreator ssc = new SwaggerSpecificationCreator();
+		ssc.getJSON();
+
+		// check our custom methods were called
+		assertTrue(UnrelatedGenericChildResource.getGETCalled);
+		assertTrue(UnrelatedGenericChildResource.getCREATECalled);
+		assertTrue(UnrelatedGenericChildResource.getUPDATECalled);
+
+		// assert the definition is now in the swagger object
+		Swagger swagger = ssc.getSwagger();
+		assertTrue(swagger.getDefinitions().containsKey("UnrelatedGet"));
+		assertTrue(swagger.getDefinitions().containsKey("UnrelatedUpdate"));
+		assertTrue(swagger.getDefinitions().containsKey("UnrelatedCreate"));
 	}
 }

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/doc/SwaggerSpecificationCreatorTest.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/doc/SwaggerSpecificationCreatorTest.java
@@ -144,7 +144,7 @@ public class SwaggerSpecificationCreatorTest extends BaseModuleWebContextSensiti
 		Assert.assertTrue("Ensure that no data was added or removed from any tables",
 		    ensureCountsEqual(beforeCounts, afterCounts));
 	}
-
+	
 	private boolean ensureCountsEqual(Map<String, Integer> beforeCounts, Map<String, Integer> afterCounts) {
 		for (String key : beforeCounts.keySet()) {
 			if (beforeCounts.get(key) != afterCounts.get(key)) {
@@ -272,24 +272,29 @@ public class SwaggerSpecificationCreatorTest extends BaseModuleWebContextSensiti
 	}
 
 	/**
-	 * Ensure that resources not directly related to the webservices.rest package are successfully defined in the swagger
-	 * documentation.
+	 * Ensure that resources not directly related to the webservices.rest package are successfully
+	 * defined in the swagger documentation.
 	 */
 	@Test
 	public void testUnrelatedResourceDefinitions() {
-		// check the statics are false first
-		assertFalse(UnrelatedGenericChildResource.getGETCalled);
-		assertFalse(UnrelatedGenericChildResource.getCREATECalled);
-		assertFalse(UnrelatedGenericChildResource.getUPDATECalled);
+		// ensure the statics are false first
+		UnrelatedGenericChildResource.getGETCalled = false;
+		UnrelatedGenericChildResource.getCREATECalled = false;
+		UnrelatedGenericChildResource.getUPDATECalled = false;
+
+		// make sure to reset the cache for multiple tests in the same run
+		if (SwaggerSpecificationCreator.isCached()) {
+			SwaggerSpecificationCreator.clearCache();
+		}
 
 		SwaggerSpecificationCreator ssc = new SwaggerSpecificationCreator();
 		ssc.getJSON();
-
+		
 		// check our custom methods were called
 		assertTrue(UnrelatedGenericChildResource.getGETCalled);
 		assertTrue(UnrelatedGenericChildResource.getCREATECalled);
 		assertTrue(UnrelatedGenericChildResource.getUPDATECalled);
-
+		
 		// assert the definition is now in the swagger object
 		Swagger swagger = ssc.getSwagger();
 		assertTrue(swagger.getDefinitions().containsKey("UnrelatedGet"));

--- a/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SwaggerSpecificationCreator.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/docs/swagger/SwaggerSpecificationCreator.java
@@ -987,12 +987,6 @@ public class SwaggerSpecificationCreator {
 		Model model = null;
 		Model modelRef = null;
 		Model modelFull = null;
-		//FIXME ex:
-		// java.lang.AbstractMethodError: org.openmrs.module.reportingrest.web.resource.EvaluatedCohort
-		//		resourceHandler.getClass().getMethod("getGETModel", Representation.class);
-		if (!resourceHandler.getClass().getName().startsWith("org.openmrs.module.webservices.rest")) {
-			return;
-		}
 		
 		if (definitionName.endsWith("Get")) {
 			model = resourceHandler.getGETModel(Representation.DEFAULT);


### PR DESCRIPTION
Fix for ticket [RESTWS-721](https://issues.openmrs.org/browse/RESTWS-721). 
Add failing test checking for appropriate method calls and definitions in the compiled swagger.
Implement a fix deleting the offending code to allow tests to pass.

Builds on-top of #342 as changes required for tests to work.