### PR TITLE
UHM-3497: Bug fix, do not return duplicate encounters for search by obs

### DIFF
--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9.java
@@ -120,11 +120,7 @@ public class EncounterSearchHandler1_9 implements SearchHandler {
 							
 							// return encounters for filtered obs
 							if (filteredObs.size() > 0) {
-								List<Encounter> encounters = new ArrayList<Encounter>();
-								obsIterator = filteredObs.iterator();
-								while (obsIterator.hasNext()) {
-									encounters.add(obsIterator.next().getEncounter());
-								}
+								List<Encounter> encounters = this.getEncountersForObs(filteredObs.iterator());
 								
 								return new NeedsPaging<Encounter>(encounters, context);
 							}
@@ -132,10 +128,7 @@ public class EncounterSearchHandler1_9 implements SearchHandler {
 					}
 					else {
 						// return all encounters with obs matching concept
-						List<Encounter> encounters = new ArrayList<Encounter>();
-						while (obsIterator.hasNext()) {
-							encounters.add(obsIterator.next().getEncounter());
-						}
+						List<Encounter> encounters = this.getEncountersForObs(obsIterator);
 						
 						return new NeedsPaging<Encounter>(encounters, context);
 					}
@@ -168,5 +161,31 @@ public class EncounterSearchHandler1_9 implements SearchHandler {
 		}
 		
 		return found;
+	}
+	
+	private List<Encounter> getEncountersForObs(Iterator<Obs> obsIterator) {
+		List<Encounter> encounters = new ArrayList<Encounter>();
+		Encounter currEncounter;
+		while (obsIterator.hasNext()) {
+			currEncounter = obsIterator.next().getEncounter();
+			if (!this.containsEncounter(encounters, currEncounter)) {
+				encounters.add(currEncounter);
+			}
+		}
+		
+		return encounters;
+	}
+	
+	private boolean containsEncounter(List<Encounter> encounters, Encounter encounter) {
+		boolean containsFlag = false;
+		Iterator<Encounter> encIterator = encounters.iterator();
+		while (encIterator.hasNext()) {
+			if (encIterator.next().getUuid().equalsIgnoreCase(encounter.getUuid())) {
+				containsFlag = true;
+				break;
+			}
+		}
+		
+		return containsFlag;
 	}
 }

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9Test.java
@@ -109,7 +109,7 @@ public class EncounterSearchHandler1_9Test extends RestControllerTestUtils {
 		
 		SimpleObject result = deserialize(handle(req));
 		List<Encounter> encounters = result.get("results");
-		Assert.assertEquals(2, encounters.size());
+		Assert.assertEquals(1, encounters.size());
 	}
 	
 	/**


### PR DESCRIPTION
https://tickets.pih-emr.org/browse/UHM-3497

Fixed a bug where duplicate encounters were being returned from EncounterSearchHandler.