### PR TITLE
RESTWS-702 : Add support for unvoiding/unretiring resources

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
@@ -207,6 +207,18 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#undelete(java.lang.Object,
+	 *      org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	protected Encounter undelete(Encounter enc, RequestContext context) throws ResponseException {
+		if (enc.isVoided()) {
+			enc = Context.getEncounterService().unvoidEncounter(enc);
+		}
+		return enc;
+	}
+	
+	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#purge(org.openmrs.Encounter,
 	 *      org.openmrs.module.webservices.rest.web.RequestContext)
 	 */

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -84,6 +84,18 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#undelete(java.lang.Object,
+	 *      org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	protected Obs undelete(Obs delegate, RequestContext context) throws ResponseException {
+		if (delegate.isVoided()) {
+			delegate = Context.getObsService().unvoidObs(delegate);
+		}
+		return delegate;
+	}
+	
+	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getByUniqueId(java.lang.String)
 	 */
 	@Override

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
@@ -90,6 +90,18 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#undelete(java.lang.Object,
+	 *      org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	protected Order undelete(Order delegate, RequestContext context) throws ResponseException {
+		if (delegate.isVoided()) {
+			delegate = Context.getOrderService().unvoidOrder(delegate);
+		}
+		return delegate;
+	}
+	
+	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#purge(java.lang.Object,
 	 *      org.openmrs.module.webservices.rest.web.RequestContext)
 	 */

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
@@ -280,6 +280,18 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#undelete(java.lang.Object,
+	 *      org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	protected Patient undelete(Patient patient, RequestContext context) throws ResponseException {
+		if (patient.isVoided()) {
+			patient = Context.getPatientService().unvoidPatient(patient);
+		}
+		return patient;
+	}
+	
+	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#purge(java.lang.Object,
 	 *      org.openmrs.module.webservices.rest.web.RequestContext)
 	 */

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
@@ -432,6 +432,18 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#undelete(java.lang.Object,
+	 *      org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	protected Person undelete(Person person, RequestContext context) throws ResponseException {
+		if (person.isVoided()) {
+			person = Context.getPersonService().unvoidPerson(person);
+		}
+		return person;
+	}
+	
+	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#purge(java.lang.Object,
 	 *      org.openmrs.module.webservices.rest.web.RequestContext)
 	 */

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
@@ -58,6 +58,14 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 	}
 	
 	@Override
+	protected PatientProgram undelete(PatientProgram delegate, RequestContext context) throws ResponseException {
+		if (delegate.isVoided()) {
+			delegate = Context.getProgramWorkflowService().unvoidPatientProgram(delegate);
+		}
+		return delegate;
+	}
+	
+	@Override
 	public void purge(PatientProgram delegate, RequestContext context) throws ResponseException {
 		Context.getProgramWorkflowService().purgePatientProgram(delegate);
 	}

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
@@ -52,6 +52,14 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 	}
 	
 	@Override
+	protected Relationship undelete(Relationship delegate, RequestContext context) throws ResponseException {
+		if (delegate.isVoided()) {
+			delegate = Context.getPersonService().unvoidRelationship(delegate);
+		}
+		return delegate;
+	}
+	
+	@Override
 	public Relationship newDelegate() {
 		return new Relationship();
 	}

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptClassController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptClassController1_8Test.java
@@ -10,11 +10,13 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
 import java.util.List;
+import java.util.Date;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.ConceptClass;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -91,6 +93,24 @@ public class ConceptClassController1_8Test extends MainResourceControllerTest {
 		handle(req);
 		Assert.assertEquals(true, service.getConceptClassByUuid(uuid).isRetired());
 		Assert.assertEquals(reason, service.getConceptClassByUuid(uuid).getRetireReason());
+	}
+	
+	@Test
+	public void shouldUnRetireAConceptClass() throws Exception {
+		ConceptClass conceptClass = service.getConceptClassByUuid(getUuid());
+		conceptClass.setRetired(true);
+		conceptClass.setRetireReason("random reason");
+		service.saveConceptClass(conceptClass);
+		conceptClass = service.getConceptClassByUuid(getUuid());
+		Assert.assertTrue(conceptClass.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		conceptClass = service.getConceptClassByUuid(getUuid());
+		Assert.assertFalse(conceptClass.isRetired());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 	@Test

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptSourceController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptSourceController1_8Test.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
+import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;
@@ -137,6 +138,24 @@ public class ConceptSourceController1_8Test extends MainResourceControllerTest {
 		handle(req);
 		Assert.assertEquals(true, service.getConceptSourceByUuid(getUuid()).isRetired());
 		Assert.assertEquals(reason, service.getConceptSourceByUuid(getUuid()).getRetireReason());
+	}
+	
+	@Test
+	public void shouldUnRetireAConceptSource() throws Exception {
+		ConceptSource conceptSource = service.getConceptSourceByUuid(getUuid());
+		conceptSource.setRetired(true);
+		conceptSource.setRetireReason("random reason");
+		service.saveConceptSource(conceptSource);
+		conceptSource = service.getConceptSourceByUuid(getUuid());
+		Assert.assertTrue(conceptSource.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		conceptSource = service.getConceptSourceByUuid(getUuid());
+		Assert.assertFalse(conceptSource.isRetired());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 	@Test

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/EncounterTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/EncounterTypeController1_8Test.java
@@ -12,7 +12,11 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
+import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;
@@ -129,6 +133,24 @@ public class EncounterTypeController1_8Test extends MainResourceControllerTest {
 		handle(req);
 		assertEquals(true, service.getEncounterTypeByUuid(getUuid()).isRetired());
 		assertEquals(reason, service.getEncounterTypeByUuid(getUuid()).getRetireReason());
+	}
+	
+	@Test
+	public void shouldUnRetireAnEncounterType() throws Exception {
+		EncounterType encounterType = service.getEncounterTypeByUuid(getUuid());
+		encounterType.setRetired(true);
+		encounterType.setRetireReason("random reason");
+		service.saveEncounterType(encounterType);
+		encounterType = service.getEncounterTypeByUuid(getUuid());
+		assertTrue(encounterType.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		encounterType = service.getEncounterTypeByUuid(getUuid());
+		assertFalse(encounterType.isRetired());
+		assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 	@Test

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
@@ -9,13 +9,28 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+import org.openmrs.FieldType;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.FormService;
+import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.apache.commons.beanutils.PropertyUtils;
 
 /**
  * Tests functionality of {@link FieldTypeController}.
  */
 public class FieldTypeController1_8Test extends MainResourceControllerTest {
+	
+	private FormService service;
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest#getURI()
@@ -39,6 +54,29 @@ public class FieldTypeController1_8Test extends MainResourceControllerTest {
 	@Override
 	public long getAllCount() {
 		return 2;
+	}
+	
+	@Before
+	public void before() {
+		this.service = Context.getFormService();
+	}
+	
+	@Test
+	public void shouldUnRetireAFieldType() throws Exception {
+		FieldType fieldType = service.getFieldTypeByUuid(getUuid());
+		fieldType.setRetired(true);
+		fieldType.setRetireReason("random reason");
+		service.saveFieldType(fieldType);
+		fieldType = service.getFieldTypeByUuid(getUuid());
+		assertTrue(fieldType.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		fieldType = service.getFieldTypeByUuid(getUuid());
+		assertFalse(fieldType.isRetired());
+		assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 }

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FormController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FormController1_8Test.java
@@ -9,13 +9,28 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+import org.openmrs.Form;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.FormService;
+import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.apache.commons.beanutils.PropertyUtils;
 
 /**
  * Tests functionality of {@link FormController}.
  */
 public class FormController1_8Test extends MainResourceControllerTest {
+	
+	private FormService service;
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest#getURI()
@@ -39,6 +54,29 @@ public class FormController1_8Test extends MainResourceControllerTest {
 	@Override
 	public long getAllCount() {
 		return 1;
+	}
+	
+	@Before
+	public void before() {
+		this.service = Context.getFormService();
+	}
+	
+	@Test
+	public void shouldUnRetireAForm() throws Exception {
+		Form form = service.getFormByUuid(getUuid());
+		form.setRetired(true);
+		form.setRetireReason("random reason");
+		service.saveForm(form);
+		form = service.getFormByUuid(getUuid());
+		assertTrue(form.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		form = service.getFormByUuid(getUuid());
+		assertFalse(form.isRetired());
+		assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 }

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PatientIdentifierTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PatientIdentifierTypeController1_8Test.java
@@ -12,7 +12,11 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
+import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;
@@ -128,6 +132,24 @@ public class PatientIdentifierTypeController1_8Test extends MainResourceControll
 		handle(req);
 		assertEquals(true, service.getPatientIdentifierTypeByUuid(getUuid()).isRetired());
 		assertEquals(reason, service.getPatientIdentifierTypeByUuid(getUuid()).getRetireReason());
+	}
+	
+	@Test
+	public void shouldUnRetireAPatientIdentifierType() throws Exception {
+		PatientIdentifierType patientIdentifierType = service.getPatientIdentifierTypeByUuid(getUuid());
+		patientIdentifierType.setRetired(true);
+		patientIdentifierType.setRetireReason("random reason");
+		service.savePatientIdentifierType(patientIdentifierType);
+		patientIdentifierType = service.getPatientIdentifierTypeByUuid(getUuid());
+		assertTrue(patientIdentifierType.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		patientIdentifierType = service.getPatientIdentifierTypeByUuid(getUuid());
+		assertFalse(patientIdentifierType.isRetired());
+		assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 	@Test

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PersonAttributeTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PersonAttributeTypeController1_8Test.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
 import java.util.List;
+import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;
@@ -151,6 +152,26 @@ public class PersonAttributeTypeController1_8Test extends MainResourceController
 		Assert.assertNotNull(obj);
 		Assert.assertTrue(obj.isRetired());
 		Assert.assertTrue("unit test".equals(obj.getRetireReason()));
+	}
+	
+	@Test
+	public void shouldUnRetireAPersonAttributeType() throws Exception {
+		
+		final String nonRetiredAttribute = "a0f5521c-dbbd-4c10-81b2-1b7ab18330df";
+		PersonAttributeType personAttrType = service.getPersonAttributeTypeByUuid(nonRetiredAttribute);
+		personAttrType.setRetired(true);
+		personAttrType.setRetireReason("random reason");
+		service.savePersonAttributeType(personAttrType);
+		personAttrType = service.getPersonAttributeTypeByUuid(nonRetiredAttribute);
+		Assert.assertTrue(personAttrType.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + nonRetiredAttribute, json)));
+		
+		personAttrType = service.getPersonAttributeTypeByUuid(nonRetiredAttribute);
+		Assert.assertFalse(personAttrType.isRetired());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 	/**

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RelationshipTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RelationshipTypeController1_8Test.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
+import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -100,6 +101,24 @@ public class RelationshipTypeController1_8Test extends MainResourceControllerTes
 		relationshipType = service.getRelationshipTypeByUuid(RestTestConstants1_8.RELATIONSHIP_TYPE_UUID);
 		Assert.assertTrue(relationshipType.isRetired());
 		Assert.assertEquals("test reason", relationshipType.getRetireReason());
+	}
+	
+	@Test
+	public void shouldUnRetireARelationshipType() throws Exception {
+		RelationshipType relationshipType = service.getRelationshipTypeByUuid(RestTestConstants1_8.RELATIONSHIP_TYPE_UUID);
+		relationshipType.setRetired(true);
+		relationshipType.setRetireReason("random reason");
+		service.saveRelationshipType(relationshipType);
+		relationshipType = service.getRelationshipTypeByUuid(RestTestConstants1_8.RELATIONSHIP_TYPE_UUID);
+		Assert.assertTrue(relationshipType.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		relationshipType = service.getRelationshipTypeByUuid(RestTestConstants1_8.RELATIONSHIP_TYPE_UUID);
+		Assert.assertFalse(relationshipType.isRetired());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 	@Test

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RoleController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RoleController1_8Test.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
 import java.util.List;
+import java.util.Date;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -159,6 +160,24 @@ public class RoleController1_8Test extends MainResourceControllerTest {
 		Role retiredRole = service.getRoleByUuid(getUuid());
 		Assert.assertTrue(retiredRole.isRetired());
 		Assert.assertEquals("random reason", retiredRole.getRetireReason());
+		
+	}
+	
+	@Test
+	public void shouldUnRetireARole() throws Exception {
+		Role role = service.getRoleByUuid(getUuid());
+		role.setRetired(true);
+		role.setRetireReason("random reason");
+		service.saveRole(role);
+		role = service.getRoleByUuid(getUuid());
+		Assert.assertTrue(role.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		role = service.getRoleByUuid(getUuid());
+		Assert.assertFalse(role.isRetired());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
 		
 	}
 	

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
@@ -252,6 +252,14 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 		Context.getVisitService().voidVisit(visit, reason);
 	}
 	
+	@Override
+	protected Visit undelete(Visit visit, RequestContext context) throws ResponseException {
+		if (visit.isVoided()) {
+			visit = Context.getVisitService().unvoidVisit(visit);
+		}
+		return visit;
+	}
+	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#purge(java.lang.Object,
 	 *      org.openmrs.module.webservices.rest.web.RequestContext)

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_9;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -480,6 +481,23 @@ public class EncounterController1_9Test extends MainResourceControllerTest {
 		Assert.assertEquals(initialCount, updatedEncounter.getEncounterProviders().size());
 		Assert.assertNotNull(updatedEncounter);
 		Assert.assertEquals(es.getEncounterRoleByUuid(newRoleUuid), updateEncounterProvider.getEncounterRole());
+	}
+	
+	@Test
+	public void shouldUnVoidAnEncounter() throws Exception {
+		EncounterService es = Context.getEncounterService();
+		Encounter encounter = es.getEncounterByUuid(RestTestConstants1_9.ENCOUNTER_UUID);
+		es.voidEncounter(encounter, "some random reason");
+		encounter = es.getEncounterByUuid(RestTestConstants1_9.ENCOUNTER_UUID);
+		Assert.assertTrue(encounter.isVoided());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + RestTestConstants1_9.ENCOUNTER_UUID, json)));
+		
+		encounter = es.getEncounterByUuid(RestTestConstants1_9.ENCOUNTER_UUID);
+		Assert.assertFalse(encounter.isVoided());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "voided").toString());
+		
 	}
 	
 	private EncounterProvider getEncounterProviderWthUuid(Set<EncounterProvider> eps, String uuid) {

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/FieldController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/FieldController1_9Test.java
@@ -9,13 +9,28 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_9;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+import org.openmrs.Field;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.FormService;
+import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.apache.commons.beanutils.PropertyUtils;
 
 /**
  * Tests functionality of {@link FieldController}.
  */
 public class FieldController1_9Test extends MainResourceControllerTest {
+	
+	private FormService service;
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest#getURI()
@@ -41,4 +56,26 @@ public class FieldController1_9Test extends MainResourceControllerTest {
 		return 1;
 	}
 	
+	@Before
+	public void before() {
+		this.service = Context.getFormService();
+	}
+	
+	@Test
+	public void shouldUnRetireAField() throws Exception {
+		Field field = service.getFieldByUuid(getUuid());
+		field.setRetired(true);
+		field.setRetireReason("random reason");
+		service.saveField(field);
+		field = service.getFieldByUuid(getUuid());
+		assertTrue(field.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		field = service.getFieldByUuid(getUuid());
+		assertFalse(field.isRetired());
+		assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
+	}
 }

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/OrderController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/OrderController1_9Test.java
@@ -228,6 +228,23 @@ public class OrderController1_9Test extends MainResourceControllerTest {
 	}
 	
 	@Test
+	public void shouldUnVoidAnOrder() throws Exception {
+		service = Context.getOrderService();
+		Order order = service.getOrderByUuid(getUuid());
+		service.voidOrder(order, "some random reason");
+		order = service.getOrderByUuid(getUuid());
+		Assert.assertTrue(order.isVoided());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		order = service.getOrderByUuid(getUuid());
+		Assert.assertFalse(order.isVoided());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "voided").toString());
+		
+	}
+	
+	@Test
 	public void shouldUpdateDrugOrder() throws Exception {
 		
 		SimpleObject content = new SimpleObject();

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PatientController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PatientController1_9Test.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Before;
@@ -126,6 +127,23 @@ public class PatientController1_9Test extends MainResourceControllerTest {
 		patient = service.getPatientByUuid(getUuid());
 		assertTrue(patient.isVoided());
 		assertEquals(reason, patient.getVoidReason());
+	}
+	
+	@Test
+	public void shouldUnVoidAPatient() throws Exception {
+		service = Context.getPatientService();
+		Patient patient = service.getPatientByUuid(getUuid());
+		service.voidPatient(patient, "some random reason");
+		patient = service.getPatientByUuid(getUuid());
+		assertTrue(patient.isVoided());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		patient = service.getPatientByUuid(getUuid());
+		assertFalse(patient.isVoided());
+		assertEquals("false", PropertyUtils.getProperty(response, "voided").toString());
+		
 	}
 	
 	@Test

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonController1_9Test.java
@@ -222,6 +222,22 @@ public class PersonController1_9Test extends MainResourceControllerTest {
 	}
 	
 	@Test
+	public void shouldUnVoidAPerson() throws Exception {
+		Person person = service.getPersonByUuid(getUuid());
+		service.voidPerson(person, "some random reason");
+		person = service.getPersonByUuid(getUuid());
+		assertTrue(person.isVoided());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		person = service.getPersonByUuid(getUuid());
+		assertFalse(person.isVoided());
+		assertEquals("false", PropertyUtils.getProperty(response, "voided").toString());
+		
+	}
+	
+	@Test
 	public void shouldPurgeAPerson() throws Exception {
 		final String uuid = "86526ed6-3c11-11de-a0ba-001e378eb67e";
 		assertNotNull(service.getPersonByUuid(uuid));

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProgramController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProgramController1_9Test.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
 
 /**
  * Tests functionality of Program CRUD by MainResourceController
@@ -151,6 +152,24 @@ public class ProgramController1_9Test extends MainResourceControllerTest {
 		Program retiredProgram = service.getProgram(2);
 		Assert.assertTrue(retiredProgram.isRetired());
 		Assert.assertEquals("some good reason", retiredProgram.getRetireReason());
+	}
+	
+	@Test
+	public void shouldUnRetireAProgram() throws Exception {
+		Program program = service.getProgramByUuid(getUuid());
+		program.setRetired(true);
+		program.setRetireReason("random reason");
+		service.saveProgram(program);
+		program = service.getProgramByUuid(getUuid());
+		Assert.assertTrue(program.isRetired());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		program = service.getProgramByUuid(getUuid());
+		Assert.assertFalse(program.isRetired());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
+		
 	}
 	
 	@Test

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProgramEnrollmentController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProgramEnrollmentController1_9Test.java
@@ -200,6 +200,22 @@ public class ProgramEnrollmentController1_9Test extends MainResourceControllerTe
 	}
 	
 	@Test
+	public void shouldUnVoidAPatientProgram() throws Exception {
+		PatientProgram patientProgram = service.getPatientProgramByUuid(getUuid());
+		service.voidPatientProgram(patientProgram, "some random reason");
+		patientProgram = service.getPatientProgramByUuid(getUuid());
+		Assert.assertTrue(patientProgram.isVoided());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		patientProgram = service.getPatientProgramByUuid(getUuid());
+		Assert.assertFalse(patientProgram.isVoided());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "voided").toString());
+		
+	}
+	
+	@Test
 	public void shouldPurgeAPatientProgram() throws Exception {
 		Assert.assertNotNull(service.getPatientProgramByUuid(getUuid()));
 		handle(newDeleteRequest(getURI() + "/" + getUuid(), new Parameter("purge", "true")));

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/RelationshipController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/RelationshipController1_9Test.java
@@ -105,6 +105,22 @@ public class RelationshipController1_9Test extends MainResourceControllerTest {
 	}
 	
 	@Test
+	public void shouldUnVoidARelationship() throws Exception {
+		Relationship relationship = service.getRelationshipByUuid(RestTestConstants1_8.RELATIONSHIP_UUID);
+		service.voidRelationship(relationship, "some random reason");
+		relationship = service.getRelationshipByUuid(RestTestConstants1_8.RELATIONSHIP_UUID);
+		Assert.assertTrue(relationship.isVoided());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		relationship = service.getRelationshipByUuid(getUuid());
+		Assert.assertFalse(relationship.isVoided());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "voided").toString());
+		
+	}
+	
+	@Test
 	public void shouldPurgeARelatonship() throws Exception {
 		Assert.assertNotNull(service.getRelationshipByUuid(RestTestConstants1_8.RELATIONSHIP_UUID));
 		int originalCount = service.getAllRelationships().size();

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/VisitController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/VisitController1_9Test.java
@@ -258,6 +258,22 @@ public class VisitController1_9Test extends MainResourceControllerTest {
 	}
 	
 	@Test
+	public void shouldUnVoidAVisit() throws Exception {
+		Visit visit = service.getVisitByUuid(RestTestConstants1_9.VISIT_UUID);
+		service.voidVisit(visit, "some random reason");
+		visit = service.getVisitByUuid(RestTestConstants1_9.VISIT_UUID);
+		Assert.assertTrue(visit.isVoided());
+		
+		String json = "{\"deleted\": \"false\"}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
+		
+		visit = service.getVisitByUuid(getUuid());
+		Assert.assertFalse(visit.isVoided());
+		Assert.assertEquals("false", PropertyUtils.getProperty(response, "voided").toString());
+		
+	}
+	
+	@Test
 	public void shouldPurgeAVisit() throws Exception {
 		Assert.assertNotNull(service.getVisitByUuid(RestTestConstants1_9.VISIT_UUID));
 		int originalCount = service.getAllVisits().size();

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/api/Deletable.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/api/Deletable.java
@@ -28,4 +28,16 @@ public interface Deletable extends Resource {
 	 */
 	void delete(String uuid, String reason, RequestContext context) throws ResponseException;
 	
+	/**
+	 * Undeletes the specified resource, which in the OpenMRS context means either unvoiding or
+	 * unretiring it
+	 * 
+	 * @param uuid Uuid for the resource to unvoid/unretire
+	 * @param context Holds information related to a REST web service request
+	 * @throws ResponseException
+	 * @return unvoided/unretired object
+	 * @since 2.25.0
+	 */
+	Object undelete(String uuid, RequestContext context) throws ResponseException;
+	
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -264,6 +264,22 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 	protected abstract void delete(T delegate, String reason, RequestContext context) throws ResponseException;
 	
 	/**
+	 * Unvoid or unretire delegate, whichever action is appropriate for the resource type.
+	 * Subclasses need to override this method, which is called internally by
+	 * {@link #undelete(String, RequestContext)}.
+	 * 
+	 * @param delegate
+	 * @param context
+	 * @throws ResponseException
+	 * @return Object
+	 */
+	protected T undelete(T delegate, RequestContext context) throws ResponseException {
+		//Default implementation of this method if not overriden by sub-class is to raise an 
+		//exception stating "undelete action not yet supported for this resource"
+		throw new ResourceDoesNotSupportOperationException("undelete action not yet supported for this resource");
+	}
+	
+	/**
 	 * Purge delegate from persistent storage. Subclasses need to override this method, which is
 	 * called internally by {@link #purge(String, RequestContext)}.
 	 * 

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingCrudResource.java
@@ -167,6 +167,21 @@ public abstract class DelegatingCrudResource<T> extends BaseDelegatingResource<T
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.api.Deletable#undelete(java.lang.String,
+	 *      org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	public Object undelete(String uuid, RequestContext context) throws ResponseException {
+		T delegate = getByUniqueId(uuid);
+		if (delegate == null)
+			throw new ObjectNotFoundException();
+		
+		delegate = undelete(delegate, context);
+		SimpleObject ret = (SimpleObject) ConversionUtil.convertToRepresentation(delegate, context.getRepresentation());
+		return ret;
+	}
+	
+	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.api.Purgeable#purge(java.lang.String)
 	 */
 	@Override

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
@@ -138,6 +138,24 @@ public abstract class MetadataDelegatingCrudResource<T extends OpenmrsMetadata> 
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#undelete(java.lang.Object,
+	 *      org.openmrs.module.webservices.rest.web.RequestContext)
+	 */
+	@Override
+	protected T undelete(T delegate, RequestContext context) throws ResponseException {
+		if (delegate.isRetired()) {
+			delegate.setRetired(false);
+			delegate.setRetiredBy(null);
+			delegate.setDateRetired(null);
+			delegate.setRetireReason(null);
+			delegate.setChangedBy(Context.getAuthenticatedUser());
+			delegate.setDateChanged(new Date());
+			delegate = save(delegate);
+		}
+		return delegate;
+	}
+	
+	/**
 	 * Gets the display string, which is specific to {@link OpenmrsMetadata}
 	 * 
 	 * @param delegate the meta-data object.

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/MainResourceController.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/MainResourceController.java
@@ -123,9 +123,17 @@ public class MainResourceController extends BaseRestController {
 	        throws ResponseException {
 		baseUriSetup.setup(request);
 		RequestContext context = RestUtil.getRequestContext(request, response);
-		Updatable res = (Updatable) restService.getResourceByName(buildResourceName(resource));
-		Object updated = res.update(uuid, post, context);
-		return RestUtil.updated(response, updated);
+		
+		if (post.get("deleted") != null && "false".equals(post.get("deleted")) && post.size() == 1) {
+			Deletable res = (Deletable) restService.getResourceByName(buildResourceName(resource));
+			Object undeletedRes = res.undelete(uuid, context);
+			return RestUtil.updated(response, undeletedRes);
+		}
+		else {
+			Updatable res = (Updatable) restService.getResourceByName(buildResourceName(resource));
+			Object updated = res.update(uuid, post, context);
+			return RestUtil.updated(response, updated);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
RESTWS-702 Add support for unvoiding/unretiring resources
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
Updated "`Deletable`" interface to also support: `undelete(String uuid, RequestContext context) throws ResponseException;`

Made `DelegatingCrudeResource` class to implement this method (`undelete(String uuid, RequestContext context) throws ResponseException;`)

Updated `BaseDelegatingResource` class to have a protected `unDelete(Object, RequestContext)` which temporarily/by-default provides for an alternative message for the classes that have not yet overridden this method. This pattern follows the design used by  `delete(Object, String, RequestContext) throws ResponseException;` method in the same class.

Overrode the `unDelete(Object, RequestContext)` for the following Resources:

-> `PatientResource1_8`
-> `PersonResource1_8`
-> `ObsResource1_8`
-> `OrderResource1_8`
-> `EncounterResource1_8`

I am welcoming comments and enhancements on resources connected to `Voidable` `Openmrs Object`s to include.

<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-702

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. 

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.


