### PR TITLE
RESTWS-658 : Person web service allow checking if person has a Patien…

### DIFF
--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonController1_9Test.java
@@ -83,6 +83,23 @@ public class PersonController1_9Test extends MainResourceControllerTest {
 	}
 	
 	@Test
+	public void shouldGetALinkIfPersonIsPatient() throws Exception {
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI() + "/" + getUuid());
+		SimpleObject result = deserialize(handle(req));
+		
+		List<Object> links = (List<Object>) result.get("links");
+		String expectedLink = RestConstants.URI_PREFIX + "v1/patient/" + RestTestConstants1_8.PATIENT_UUID;
+		String recievedLink = null;
+		for (Object link : links.toArray()) {
+			if ("patient".equals((String) PropertyUtils.getProperty(link, "rel"))) {
+				recievedLink = (String) PropertyUtils.getProperty(link, "uri");
+			}
+		}
+		assertNotNull(recievedLink);
+		assertEquals(expectedLink, recievedLink);
+	}
+	
+	@Test
 	public void shouldGetPersonDateCreated() throws Exception {
 		Person person = service.getPersonByUuid(getUuid());
 		Date personDateCreated = new Date();


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Introduced `Person` object in the `PersonResource1_8` class to help evaluate whether person in question is patient.
Introduced a method to specify `patient` resource/endpoint in the `description` 's links for the `person`  in question.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-658

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**]

- [x] I have **added tests** to cover my changes. 

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
