### PR TITLE
RESTWS-595: added a living patient search handler and added test units

### DIFF
--- a/omod-2.2/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs2_2/LivingPatientSearchHandler2_2.java
+++ b/omod-2.2/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs2_2/LivingPatientSearchHandler2_2.java
@@ -1,0 +1,78 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.webservices.rest.web.v1_0.search.openmrs2_2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchConfig;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchHandler;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchQuery;
+import org.openmrs.module.webservices.rest.web.resource.impl.EmptySearchResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LivingPatientSearchHandler2_2 implements SearchHandler {
+	
+	private final SearchConfig searchConfig = new SearchConfig("Serch for living patients", RestConstants.VERSION_1 + "/patient",
+	        Arrays.asList("1.8.*", "1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*"),
+	        Arrays.asList(new SearchQuery.Builder("Allows you to find allpatients or only living patients")
+	                .withOptionalParameters("includeDead").build()));
+
+	@Override
+	public SearchConfig getSearchConfig() {
+		return searchConfig;
+	}
+
+	
+	@Override
+	public PageableResult search(RequestContext context) throws ResponseException {
+		String includeDeadstr = context.getParameter("includeDead");
+		
+        Boolean includeDead =  StringUtils.isNotBlank(includeDeadstr) ? Boolean.parseBoolean(includeDeadstr) : false;
+        List<Patient> allPatients = Context.getPatientService().getAllPatients();
+      
+        if(includeDead) {
+        	 if (allPatients != null && allPatients.size() > 0 ) {
+        		 return new NeedsPaging<Patient>(allPatients, context);
+     		 }
+        	
+        }
+        else
+        {
+        	//Adding only living patients to the list
+        	List<Patient> livingPatients = new ArrayList<Patient>();
+        	 for (Patient patient : allPatients) {        		 
+        		 if (allPatients != null && allPatients.size() > 0 && !patient.isDead()) {
+        		
+        		livingPatients.add(patient) ;        			
+       		 }
+        		 
+        	
+        	 }
+        	 return new NeedsPaging<Patient>(livingPatients, context);
+        }
+		return 	new EmptySearchResult();
+	}
+
+	
+	
+	
+}

--- a/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs2_2/LivingPatientSearchHandler2_2Test.java
+++ b/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs2_2/LivingPatientSearchHandler2_2Test.java
@@ -1,0 +1,80 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+
+package org.openmrs.module.webservices.rest.web.v1_0.search.openmrs2_2;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.api.context.Context;import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+
+
+import java.util.List;
+
+
+public class LivingPatientSearchHandler2_2Test extends   MainResourceControllerTest {
+	
+	@Override
+	public String getURI() {
+		return "patient";
+	}
+
+	@Override
+	public String getUuid() {
+	
+		return RestTestConstants1_8.PATIENT_UUID;
+	}
+
+	@Override
+	public long getAllCount() {
+	
+		return Context.getPatientService().getAllPatients(false).size();
+	}
+	
+	@Test
+	public void getSearchConfig_shouldReturnAllPatients() throws Exception {
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+		req.addParameter("includeDead", "true");
+		
+		SimpleObject result = deserialize(handle(req));
+		List<Object> patients = (List<Object>) result.get("results");
+		Assert.assertEquals(4, patients.size());
+		
+	}
+	
+	@Test
+	public void getSearchConfig_shouldReturnOnlyLiving() throws Exception {
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+		req.addParameter("includeDead", "false");
+		
+		SimpleObject result = deserialize(handle(req));
+		List<Object> patients = (List<Object>) result.get("results");
+		Assert.assertEquals(4, patients.size());
+		
+	}
+	
+	@Test
+	public void getSearchConfig_shouldReturn() throws Exception {
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+		req.addParameter("includeDead", "wrong");
+		
+		SimpleObject result = deserialize(handle(req));
+		List<Object> patients = (List<Object>) result.get("results");
+		Assert.assertEquals(4, patients.size());
+		
+	}
+	
+	
+}


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/RESTWS-595

Added a search For only living patients using an optional parameter "includeDead"