### PR TITLE
RESTWS-708 : Capability to add a new OrderFrequency via rest

### DIFF
--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderFrequencyResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderFrequencyResource1_10.java
@@ -69,6 +69,19 @@ public class OrderFrequencyResource1_10 extends MetadataDelegatingCrudResource<O
 	}
 	
 	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getCreatableProperties()
+	 */
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		
+		description.addRequiredProperty("frequencyPerDay");
+		description.addRequiredProperty("concept");
+		
+		return description;
+	}
+	
+	/**
 	 * @see DelegatingCrudResource#newDelegate()
 	 */
 	@Override
@@ -81,7 +94,7 @@ public class OrderFrequencyResource1_10 extends MetadataDelegatingCrudResource<O
 	 */
 	@Override
 	public OrderFrequency save(OrderFrequency orderFrequency) {
-		throw new ResourceDoesNotSupportOperationException();
+		return Context.getOrderService().saveOrderFrequency(orderFrequency);
 	}
 	
 	/**


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

I added capability to create/save an order frequency using an existing Concept.


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-708

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. 

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
