### PR TITLE
RESTWS-566: Applying the DrugResource changes from platform 1.12 correctly

### DIFF
--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10.java
@@ -39,7 +39,7 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.DrugOrde
  * Exposes the {@link org.openmrs.DrugOrder} subclass as a type in
  * {@link org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10.DrugOrderSubclassHandler1_10}
  */
-@SubClassHandler(supportedClass = DrugOrder.class, supportedOpenmrsVersions = { "1.10.*", "1.11.*", "1.12.*" })
+@SubClassHandler(supportedClass = DrugOrder.class, supportedOpenmrsVersions = { "1.10.*", "1.11.*" })
 public class DrugOrderSubclassHandler1_10 extends DrugOrderSubclassHandler1_8 {
 	
 	/**

--- a/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugResource1_11.java
+++ b/omod-1.11/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugResource1_11.java
@@ -28,7 +28,7 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10.DrugRes
  * {@link Resource} for {@link Drug}, supporting standard CRUD operations
  */
 @Resource(name = RestConstants.VERSION_1 + "/drug", order = 2, supportedClass = Drug.class, supportedOpenmrsVersions = {
-        "1.11.*", "1.12.*" })
+        "1.11.*"})
 public class DrugResource1_11 extends DrugResource1_10 {
 	
 	/**

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/DrugOrderSubclassHandler1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/DrugOrderSubclassHandler1_12.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
 import org.openmrs.DrugOrder;
 import org.openmrs.module.webservices.rest.web.annotation.SubClassHandler;
@@ -21,8 +21,8 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10.DrugOrd
  * Exposes the {@link org.openmrs.DrugOrder} subclass as a type in
  * {@link org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10.DrugOrderSubclassHandler1_10}
  */
-@SubClassHandler(supportedClass = DrugOrder.class, supportedOpenmrsVersions = { "2.0.*", "2.1.*", "2.2.*" })
-public class DrugOrderSubclassHandler2_0 extends DrugOrderSubclassHandler1_10 {
+@SubClassHandler(supportedClass = DrugOrder.class, supportedOpenmrsVersions = {"1.12.*", "2.0.*", "2.1.*", "2.2.*" })
+public class DrugOrderSubclassHandler1_12 extends DrugOrderSubclassHandler1_10 {
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/DrugResource1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/DrugResource1_12.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
 import org.openmrs.Drug;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -23,8 +23,8 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11.DrugRes
  * {@link Resource} for {@link Drug}, supporting standard CRUD operations
  */
 @Resource(name = RestConstants.VERSION_1 + "/drug", order = 1, supportedClass = Drug.class, supportedOpenmrsVersions = {
-        "2.0.*", "2.1.*", "2.2.*" })
-public class DrugResource2_0 extends DrugResource1_11 {
+		"1.12.*", "2.0.*", "2.1.*", "2.2.*" })
+public class DrugResource1_12 extends DrugResource1_11 {
 	
 	/**
 	 * @see DelegatingCrudResource#getRepresentationDescription(Representation)
@@ -64,6 +64,6 @@ public class DrugResource2_0 extends DrugResource1_11 {
 	 */
 	@Override
 	public String getResourceVersion() {
-		return RestConstants2_0.RESOURCE_VERSION;
+		return RestConstants1_12.RESOURCE_VERSION;
 	}
 }

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/RestConstants1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/RestConstants1_12.java
@@ -7,15 +7,15 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.webservices.rest.web;
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
-public class RestTestConstants1_12 {
+/**
+ * {@link org.openmrs.module.webservices.rest.web.RestConstants} for 1.12 resources.
+ */
+public class RestConstants1_12 {
 	
-	public final static String TEST_DATA_SET = "customTestDataset1_12.xml";
-	
-	public final static String ORDER_SET_UUID = "order_set_uuid1";
-	
-	public final static String ORDER_SET_MEMBER_UUID = "order_set_member_uuid1";
-	
-	public static final String DRUG_UUID = "05ec820a-d297-44e3-be6e-698531d9dd3f";
+	/**
+	 * A default value for the resource version parameter.
+	 */
+	public static final String RESOURCE_VERSION = "1.12";
 }

--- a/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/DrugResource1_12Test.java
+++ b/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/DrugResource1_12Test.java
@@ -7,15 +7,16 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_12;
 
 import org.openmrs.Drug;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RestTestConstants1_12;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.RestTestConstants2_0;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0.DrugResource2_0;
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12.DrugResource1_12;
 
-public class DrugResource2_0Test extends BaseDelegatingResourceTest<DrugResource2_0, Drug> {
+
+public class DrugResource1_12Test extends BaseDelegatingResourceTest<DrugResource1_12, Drug> {
 	
 	@Override
 	public Drug newObject() {
@@ -45,6 +46,6 @@ public class DrugResource2_0Test extends BaseDelegatingResourceTest<DrugResource
 	
 	@Override
 	public String getUuidProperty() {
-		return RestTestConstants2_0.DRUG_UUID;
+		return RestTestConstants1_12.DRUG_UUID;
 	}
 }

--- a/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/OrderController1_12Test.java
+++ b/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/OrderController1_12Test.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_12;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,7 +32,7 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-public class OrderController2_0Test extends MainResourceControllerTest {
+public class OrderController1_12Test extends MainResourceControllerTest {
 	
 	protected static final String ORDER_ENTRY_DATASET_XML = "org/openmrs/api/include/OrderEntryIntegrationTest-other.xml";
 	

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/RestTestConstants2_0.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/RestTestConstants2_0.java
@@ -29,8 +29,6 @@ public class RestTestConstants2_0 {
 	
 	public static final String CONCEPT_ATTRIBUTE_UUID = "3a2bdb18-6faa-11e0-8414-001e378eb67f";
 	
-	public static final String DRUG_UUID = "05ec820a-d297-44e3-be6e-698531d9dd3f";
-	
 	public static final String PROVIDER_TEST_DATA_XML = "providerTestDataset.xml";
 	
 	public static final String PROVIDER_UUID = "e1009293-c561-47ae-b112-214052c17888";


### PR DESCRIPTION
Ticket : https://issues.openmrs.org/browse/RESTWS-566


## Issue I worked on
I  applied the DrugResource changes from platform 1.12 correctly to run when running platform 1.12
.



