### PR TITLE
RESTWS-758 Add location to session resource, with RESTful endpoints

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
@@ -150,7 +150,7 @@ public class TaskActionResource1_8 extends BaseDelegatingResource<TaskAction> im
 	private void runTasks(Collection<TaskDefinition> taskDefs) {
 		for (TaskDefinition taskDef : taskDefs) {
 			try {
-			   taskServiceWrapper.runTask(taskDef);
+				taskServiceWrapper.runTask(taskDef);
 			}
 			catch (SchedulerException e) {
 				throw new APIException("Errors occurred while running task", e);

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/TaskActionController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/TaskActionController1_8Test.java
@@ -32,13 +32,14 @@ public class TaskActionController1_8Test extends MainResourceControllerTest {
 	
 	@Autowired
 	RestService restService;
+	
 	static int count = 1;
 	
 	private TaskDefinition testTask = new TaskDefinition(1, "TestTask", "TestTask Description",
 	        "org.openmrs.scheduler.tasks.TestTask");
 	
 	private TaskDefinition testDummyTask = new TaskDefinition(5, "TestDummy", "TestTask Description",
-		DummyTask.class.getName());
+	        DummyTask.class.getName());
 	
 	private TaskDefinition tempTask = new TaskDefinition(3, "TempTask", "TempTask Description",
 	        "org.openmrs.scheduler.tasks.TestTask");
@@ -47,7 +48,7 @@ public class TaskActionController1_8Test extends MainResourceControllerTest {
 	
 	@Before
 	public void setUp() throws Exception {
-		mockTaskServiceWrapper.registeredTasks.addAll(Arrays.asList(testTask, tempTask , testDummyTask));
+		mockTaskServiceWrapper.registeredTasks.addAll(Arrays.asList(testTask, tempTask, testDummyTask));
 		
 		TaskActionResource1_8 taskActionResource = (TaskActionResource1_8) restService
 		        .getResourceBySupportedClass(TaskAction.class);
@@ -114,9 +115,10 @@ public class TaskActionController1_8Test extends MainResourceControllerTest {
 		//sanity check
 		assertThat(mockTaskServiceWrapper.registeredTasks, hasItem(testDummyTask));
 		Assert.assertEquals(mockTaskServiceWrapper.getRegisteredTasks().size(), 3);
-        //count before manual execution
+		//count before manual execution
 		int countBefore = count;
-		deserialize(handle(newPostRequest(getURI(), "{\"action\": \"runtask\", \"tasks\":[\"" + getTestDummyTaskName() + "\"]}")));
+		deserialize(handle(newPostRequest(getURI(), "{\"action\": \"runtask\", \"tasks\":[\"" + getTestDummyTaskName()
+		        + "\"]}")));
 		assertThat(mockTaskServiceWrapper.registeredTasks, hasItem(testDummyTask));
 		Assert.assertEquals(mockTaskServiceWrapper.getRegisteredTasks().size(), 3);
 		//count after manual execution
@@ -161,6 +163,7 @@ public class TaskActionController1_8Test extends MainResourceControllerTest {
 	public String getTestTaskName() {
 		return "TestTask";
 	}
+	
 	public String getTestDummyTaskName() {
 		return "TestDummy";
 	}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

Adds sessionLocation to the user context object. The GET session endpoint now includes the location. The POST session endpoint now accepts a property `sessionLocation` which should be the UUID of a location. When POST is called, it also sets the location ID on the HttpSession, for compatibility with the appui endpoint.

This clashes with https://github.com/openmrs/openmrs-module-webservices.rest/pull/418 . Maintainers?

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
https://issues.openmrs.org/browse/RESTWS-758

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

