### PR TITLE
TRUNK-5656: Fix infinite recursion in OpenmrsPathMatcher#matchStart

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/OpenmrsPathMatcher.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/OpenmrsPathMatcher.java
@@ -31,7 +31,7 @@ public class OpenmrsPathMatcher implements PathMatcher {
 	
 	@Override
 	public boolean matchStart(String pattern, String path) {
-		return this.matchStart(pattern, path);
+		return this.delegate.matchStart(pattern, path);
 	}
 	
 	@Override


### PR DESCRIPTION
Ticket ID:https://issues.openmrs.org/browse/TRUNK-5656

Description
Removed the Infinite recursive loop because method calls itself instead of delegate

