### PR TITLE
RESTWS-796: Local variables should not be declared and then immediate…

### DIFF
--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderGroupResource1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderGroupResource1_12.java
@@ -155,18 +155,16 @@ public class OrderGroupResource1_12 extends DataDelegatingCrudResource<OrderGrou
 	
 	@Override
 	public Model getCREATEModel(Representation representation) {
-		ModelImpl model = new ModelImpl().property("patient", new StringProperty().example("uuid"))
+		return new ModelImpl().property("patient", new StringProperty().example("uuid"))
 		        .property("encounter", new StringProperty().example("uuid"))
 		        .property("orders", new ArrayProperty(new RefProperty("#/definitions/OrderCreate")))
 		        .property("orderSet", new StringProperty().example("uuid"));
-		return model;
 	}
 	
 	@Override
 	public Model getUPDATEModel(Representation rep) {
-		ModelImpl model = new ModelImpl().property("orders",
+		return new ModelImpl().property("orders",
 		    new ArrayProperty(new RefProperty("#/definitions/OrderCreate")));
-		return model;
 	}
 	
 	@PropertyGetter("display")

--- a/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
+++ b/omod-1.12/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
@@ -9,12 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_12;
 
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.BooleanProperty;
-import io.swagger.models.properties.ObjectProperty;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.OrderSet;
 import org.openmrs.OrderSetMember;
 import org.openmrs.api.context.Context;
@@ -33,8 +30,12 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResour
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 
 /**
  * {@link Resource} for OrderSetMembers, supporting standard CRUD operations
@@ -100,8 +101,7 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 	 */
 	@Override
 	public DelegatingResourceDescription getUpdatableProperties() {
-		DelegatingResourceDescription creatableProperties = getCreatableProperties();
-		return creatableProperties;
+		return getCreatableProperties();
 	}
 	
 	@Override

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -526,8 +526,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		
 		obs = obsService.saveObs(obs, null);
 		
-		SimpleObject ret = (SimpleObject) ConversionUtil.convertToRepresentation(obs, Representation.DEFAULT);
-		return ret;
+		return (SimpleObject) ConversionUtil.convertToRepresentation(obs, Representation.DEFAULT);
 	}
 	
 }

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
@@ -16,13 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.ObjectProperty;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Role;
@@ -46,6 +39,14 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.module.webservices.rest.web.v1_0.wrapper.openmrs1_8.UserAndPassword1_8;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 
 /**
  * {@link Resource} for User, supporting standard CRUD operations
@@ -411,8 +412,7 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 	 */
 	@PropertyGetter("auditInfo")
 	public SimpleObject getAuditInfo(UserAndPassword1_8 delegate) throws Exception {
-		SimpleObject ret = super.getAuditInfo(delegate.getUser());
-		return ret;
+		return super.getAuditInfo(delegate.getUser());
 	}
 	
 	/**

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
@@ -11,9 +11,6 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
 import java.util.List;
 
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.APIException;
@@ -36,6 +33,10 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.StringProperty;
 
 /**
  * {@link Resource} for {@link GlobalProperty}, supporting standard CRUD operations
@@ -230,8 +231,7 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 		AdministrationService service = Context.getAdministrationService();
 		List<GlobalProperty> searchResults;
 		searchResults = service.getGlobalPropertiesByPrefix(context.getParameter("q"));
-		PageableResult result = new NeedsPaging<GlobalProperty>(searchResults, context);
-		return result;
+		return new NeedsPaging<GlobalProperty>(searchResults, context);
 	}
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/SimpleObject.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/SimpleObject.java
@@ -68,8 +68,7 @@ public class SimpleObject extends LinkedHashMap<String, Object> {
 	 */
 	public static SimpleObject parseJson(String json) throws JsonParseException, JsonMappingException, IOException {
 		ObjectMapper objectMapper = new ObjectMapper();
-		SimpleObject object = objectMapper.readValue(json, SimpleObject.class);
-		return object;
+		return objectMapper.readValue(json, SimpleObject.class);
 	}
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
@@ -240,8 +240,7 @@ public class ConversionUtil {
 				        "yyyy-MM-dd'T'HH:mm:ssXXX", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd" };
 				for (int i = 0; i < supportedFormats.length; i++) {
 					try {
-						Date date = DateTime.parse(string, DateTimeFormat.forPattern(supportedFormats[i])).toDate();
-						return date;
+						return DateTime.parse(string, DateTimeFormat.forPattern(supportedFormats[i])).toDate();
 					}
 					catch (IllegalArgumentException ex) {
 						pex = ex;

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/RestUtil.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/RestUtil.java
@@ -501,8 +501,7 @@ public class RestUtil implements GlobalPropertyListener {
 		
 		if (paramString != null) {
 			try {
-				Integer tempInt = new Integer(paramString);
-				return tempInt; // return the valid value
+				return new Integer(paramString);// return the valid value
 			}
 			catch (NumberFormatException e) {
 				log.debug("unable to parse '" + param + "' parameter into a valid integer: " + paramString);

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/api/impl/RestServiceImpl.java
@@ -472,9 +472,7 @@ public class RestServiceImpl implements RestService {
 	 */
 	private Resource newResource(Class<? extends Resource> resourceClass) {
 		try {
-			Resource resource = resourceClass.newInstance();
-			
-			return resource;
+			return resourceClass.newInstance();
 		}
 		catch (Exception ex) {
 			throw new APIException("Failed to instantiate " + resourceClass, ex);

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingConverter.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingConverter.java
@@ -64,8 +64,7 @@ public abstract class BaseDelegatingConverter<T> implements Converter<T>, Delega
 			throw new NullPointerException();
 		
 		DelegatingResourceDescription description = getRepresentationDescription(rep);
-		SimpleObject simple = convertDelegateToRepresentation(delegate, description);
-		return simple;
+		return convertDelegateToRepresentation(delegate, description);
 	}
 	
 	@Override

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -23,11 +23,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.ObjectProperty;
-import io.swagger.models.properties.StringProperty;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -60,6 +55,12 @@ import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOp
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.StringProperty;
 
 /**
  * A base implementation of a resource or sub-resource that delegates operations to a wrapped
@@ -411,9 +412,7 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		if (representation instanceof CustomRepresentation) {
 			repDescription = getCustomRepresentationDescription((CustomRepresentation) representation);
 			if (repDescription != null) {
-				SimpleObject simple = convertDelegateToRepresentation(delegate, repDescription);
-				
-				return simple;
+				return convertDelegateToRepresentation(delegate, repDescription);
 			}
 		}
 		
@@ -832,8 +831,7 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		if (handler == null)
 			return null;
 		try {
-			Method method = handler.getClass().getMethod(methodName, argumentTypes);
-			return method;
+			return handler.getClass().getMethod(methodName, argumentTypes);
 		}
 		catch (Exception e) {
 			return null;
@@ -899,8 +897,7 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 	 */
 	@Deprecated
 	protected Method findMethod(String name) {
-		Method ret = ReflectionUtil.findMethod(getClass(), name);
-		return ret;
+		return ReflectionUtil.findMethod(getClass(), name);
 	}
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingCrudResource.java
@@ -175,8 +175,7 @@ public abstract class DelegatingCrudResource<T> extends BaseDelegatingResource<T
 			throw new ObjectNotFoundException();
 		
 		delegate = undelete(delegate, context);
-		SimpleObject ret = (SimpleObject) ConversionUtil.convertToRepresentation(delegate, context.getRepresentation());
-		return ret;
+		return (SimpleObject) ConversionUtil.convertToRepresentation(delegate, context.getRepresentation());
 	}
 	
 	/**


### PR DESCRIPTION


<!--- Add a pull request title above in this format -->
<!--- RESTWS-796: Local variables should not be declared and then immediately returned' -->
## Description of what I changed
## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-796
## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ X] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [ X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

