### PR TITLE
RESTWS-800: Assertion arguments should be passed in the correct order

### DIFF
--- a/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_11/DrugIngredientController1_11Test.java
+++ b/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_11/DrugIngredientController1_11Test.java
@@ -73,7 +73,7 @@ public class DrugIngredientController1_11Test extends MainResourceControllerTest
 		Assert.assertEquals(1, resultsList.size());
 		List<Object> ingredients = Arrays.asList(PropertyUtils.getProperty(resultsList.get(0), "ingredient"));
 		
-		Assert.assertEquals(((Map) ingredients.get(0)).get("display"), "ASPIRIN");
-		Assert.assertEquals(((Map) ingredients.get(0)).get("uuid"), "15f83cd6-64e9-4e06-a5f9-364d3b14a43d");
+		Assert.assertEquals("ASPIRIN", ((Map) ingredients.get(0)).get("display"));
+		Assert.assertEquals("15f83cd6-64e9-4e06-a5f9-364d3b14a43d", ((Map) ingredients.get(0)).get("uuid"));
 	}
 }

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/HL7MessageController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/HL7MessageController1_8Test.java
@@ -68,7 +68,7 @@ public class HL7MessageController1_8Test extends MainResourceControllerTest {
 		Assert.assertEquals(before + 1, service.getAllHL7InQueues().size());
 		for (HL7InQueue hl7InQueue : service.getAllHL7InQueues()) {
 			if (hl7InQueue.getUuid().equals(newHl7Message.get("uuid"))) {
-				Assert.assertEquals(hl7InQueue.getHL7Data(), hl7Data);
+				Assert.assertEquals(hl7Data, hl7InQueue.getHL7Data());
 			}
 		}
 	}
@@ -86,7 +86,7 @@ public class HL7MessageController1_8Test extends MainResourceControllerTest {
 		Assert.assertEquals(before + 1, service.getAllHL7InQueues().size());
 		for (HL7InQueue hl7InQueue : service.getAllHL7InQueues()) {
 			if (hl7InQueue.getUuid().equals(newHl7Message.get("uuid"))) {
-				Assert.assertEquals(hl7InQueue.getHL7Data(), hl7Data);
+				Assert.assertEquals(hl7Data, hl7InQueue.getHL7Data());
 			}
 		}
 	}

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ServerLogController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ServerLogController1_8Test.java
@@ -68,7 +68,7 @@ public class ServerLogController1_8Test extends MainResourceControllerTest {
 	public void shouldGetAll() throws Exception {
 		//sanity check
 		List<String[]> mockServerLogs = mockServerLogActionWrapper.getServerLogs();
-		Assert.assertEquals(mockServerLogs.size(), 0);
+		Assert.assertEquals(0, mockServerLogs.size());
 
 		mockServerLogActionWrapper.mockMemoryAppenderBuffer.addAll(Arrays.asList(log1, log2));
 

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/TaskActionController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/TaskActionController1_8Test.java
@@ -114,13 +114,13 @@ public class TaskActionController1_8Test extends MainResourceControllerTest {
 	public void shouldRunTask() throws Exception {
 		//sanity check
 		assertThat(mockTaskServiceWrapper.registeredTasks, hasItem(testDummyTask));
-		Assert.assertEquals(mockTaskServiceWrapper.getRegisteredTasks().size(), 3);
+		Assert.assertEquals(3, mockTaskServiceWrapper.getRegisteredTasks().size());
 		//count before manual execution
 		int countBefore = count;
 		deserialize(handle(newPostRequest(getURI(), "{\"action\": \"runtask\", \"tasks\":[\"" + getTestDummyTaskName()
 		        + "\"]}")));
 		assertThat(mockTaskServiceWrapper.registeredTasks, hasItem(testDummyTask));
-		Assert.assertEquals(mockTaskServiceWrapper.getRegisteredTasks().size(), 3);
+		Assert.assertEquals(3, mockTaskServiceWrapper.getRegisteredTasks().size());
 		//count after manual execution
 		int countAfter = count;
 		Assert.assertEquals(++countBefore, countAfter);

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/TaskDefinitionController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/TaskDefinitionController1_8Test.java
@@ -143,7 +143,7 @@ public class TaskDefinitionController1_8Test extends MainResourceControllerTest 
 		MockHttpServletRequest req = request(RequestMethod.POST, getURI());
 		req.setContent(json.getBytes());
 		deserialize(handle(req));
-		Assert.assertEquals(mockTaskServiceWrapper.getTaskByName("MockTask").getName(), "MockTask");
+		Assert.assertEquals("MockTask", mockTaskServiceWrapper.getTaskByName("MockTask").getName());
 	}
 	
 	@Override

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8Test.java
@@ -54,7 +54,7 @@ public class ServerLogResource1_8Test extends BaseModuleWebContextSensitiveTest 
 		SimpleObject result = mainResourceController.get(getURI(), request, response);
 
 		ArrayList<String[]> serverLog = result.get("serverLog");
-		Assert.assertEquals(serverLog.size(), 0);
+		Assert.assertEquals(0, serverLog.size());
 
 		String mockLogLine1 = "INFO - Simple.appender(115) |2018-03-03 15:44:54,834| Info Message";
 		// Add some mock log lines to mockMemoryAppenderBuffer

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_8Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_8Test.java
@@ -699,7 +699,7 @@ public class ConceptController1_8Test extends MainResourceControllerTest {
 	public void shouldFindConceptsByName() throws Exception {
 		SimpleObject response = deserialize(handle(newGetRequest(getURI(), new Parameter("name", "WEIGHT (KG)"))));
 		List<Object> results = Util.getResultsList(response);
-		Assert.assertEquals(results.size(), 1);
+		Assert.assertEquals(1, results.size());
 		Object next = results.iterator().next();
 		Assert.assertThat((String) PropertyUtils.getProperty(next, "uuid"), is("c607c80f-1ea9-4da3-bb88-6276ce8868dd"));
 	}
@@ -708,7 +708,7 @@ public class ConceptController1_8Test extends MainResourceControllerTest {
 	public void shouldFailToFetchAConceptByNameIfTheNameIsNeitherPreferredNorFullySpecified() throws Exception {
 		SimpleObject response = deserialize(handle(newGetRequest(getURI(), new Parameter("name", "WT"))));
 		List<Object> results = Util.getResultsList(response);
-		Assert.assertEquals(results.size(), 0);
+		Assert.assertEquals(0, results.size());
 	}
 	
 	@Test

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_9Test.java
@@ -57,7 +57,7 @@ public class ConceptController1_9Test extends MainResourceControllerTest {
 		SimpleObject response = deserialize(handle(newGetRequest(getURI(), new Parameter("term", "SSTRM-WGT234"))));
 		List<Object> results = Util.getResultsList(response);
 		
-		Assert.assertEquals(results.size(), 1);
+		Assert.assertEquals(1, results.size());
 		Object next = results.iterator().next();
 		Assert.assertThat((String) PropertyUtils.getProperty(next, "uuid"), is("c607c80f-1ea9-4da3-bb88-6276ce8868dd"));
 	}
@@ -69,7 +69,7 @@ public class ConceptController1_9Test extends MainResourceControllerTest {
 		        "full"))));
 		List<Object> results = Util.getResultsList(response);
 		
-		Assert.assertEquals(results.size(), 1);
+		Assert.assertEquals(1, results.size());
 		Object next = results.iterator().next();
 		Assert.assertThat((String) PropertyUtils.getProperty(next, "uuid"), is("568b58c8-e878-11e0-950d-00248140a5e3"));
 	}

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsController1_9Test.java
@@ -141,7 +141,7 @@ public class ObsController1_9Test extends MainResourceControllerTest {
 		MockHttpServletResponse allNonVoidedObsResponse = handle(allNonVoidedObsRequest);
 		List<Object> allNonVoidedObsList = deserialize(allNonVoidedObsResponse).get("results");
 		
-		assertEquals(allNonVoidedObsList.size(), 6);
+		assertEquals(6, allNonVoidedObsList.size());
 		
 		MockHttpServletRequest deleteRequest = newDeleteRequest(getURI() + "/" + "11de743c-96cd-11e0-8d6b-9b9415a91465");
 		deleteRequest.addParameter("reason", "test voided obs");
@@ -153,14 +153,14 @@ public class ObsController1_9Test extends MainResourceControllerTest {
 		MockHttpServletResponse allObsIncludingVoidedResponse = handle(allObsIncludingVoidedRequest);
 		List<Object> allObsIncludingVoidedList = deserialize(allObsIncludingVoidedResponse).get("results");
 		
-		assertEquals(allObsIncludingVoidedList.size(), 6);
+		assertEquals(6, allObsIncludingVoidedList.size());
 		
 		MockHttpServletRequest allNonVoidedObsAfterDeleteRequest = newGetRequest(getURI());
 		allNonVoidedObsAfterDeleteRequest.addParameter("encounter", ENCOUNTER_UUID);
 		MockHttpServletResponse allNonVoidedObsAfterDeleteResponse = handle(allNonVoidedObsAfterDeleteRequest);
 		List<Object> allNonVoidedObsAfterDeleteList = deserialize(allNonVoidedObsAfterDeleteResponse).get("results");
 		
-		assertEquals(allNonVoidedObsAfterDeleteList.size(), 5);
+		assertEquals(5, allNonVoidedObsAfterDeleteList.size());
 	}
 	
 	@Test

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PatientIdentifierController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PatientIdentifierController1_9Test.java
@@ -138,7 +138,7 @@ public class PatientIdentifierController1_9Test extends MainResourceControllerTe
 		PatientIdentifier newIdentifer = service.getPatientIdentifierByUuid(uuid.toString());
 		assertFalse(exisitingIdentifier.isPreferred());
 		assertTrue(newIdentifer.isPreferred());
-		assertEquals(newIdentifer.getIdentifier(), "abc123ez");
+		assertEquals("abc123ez", newIdentifer.getIdentifier());
 	}
 	
 	@Test

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonNameController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonNameController1_9Test.java
@@ -102,9 +102,9 @@ public class PersonNameController1_9Test extends MainResourceControllerTest {
 		
 		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
 		Assert.assertNotNull(response);
-		Assert.assertEquals(PropertyUtils.getProperty(response, "familyName").toString(), "newName");
+		Assert.assertEquals("newName", PropertyUtils.getProperty(response, "familyName").toString());
 		PersonName editedPersonName = service.getPersonNameByUuid(getUuid());
-		Assert.assertEquals(editedPersonName.getFamilyName(), "newName");
+		Assert.assertEquals("newName", editedPersonName.getFamilyName());
 		
 	}
 	

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/SessionController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/SessionController1_9Test.java
@@ -80,7 +80,7 @@ public class SessionController1_9Test extends BaseModuleWebContextSensitiveTest 
 		Object userProp = PropertyUtils.getProperty(ret, "user");
 		List<HashMap<String, String>> userRoles = (List<HashMap<String, String>>) PropertyUtils.getProperty(userProp,
 		    "roles");
-		Assert.assertEquals(userRoles.get(0).get("name"), "System Developer");
+		Assert.assertEquals("System Developer", userRoles.get(0).get("name"));
 		Assert.assertEquals(SESSION_ID, PropertyUtils.getProperty(ret, "sessionId"));
 		Assert.assertEquals(true, PropertyUtils.getProperty(ret, "authenticated"));
 		Assert.assertEquals(Context.getAuthenticatedUser().getUuid(), PropertyUtils.getProperty(userProp, "uuid"));

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/VisitController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/VisitController1_9Test.java
@@ -341,16 +341,16 @@ public class VisitController1_9Test extends MainResourceControllerTest {
 		int visitIncludingVoidedSize = Util.getResultsSize(resultWithVoidedVisits);
 		int visitExcludingVoidedSize = Util.getResultsSize(resultWithoutVoidedVisits);
 		
-		Assert.assertEquals(visitIncludingVoidedSize, 4);
-		Assert.assertEquals(visitExcludingVoidedSize, 3);
+		Assert.assertEquals(4, visitIncludingVoidedSize);
+		Assert.assertEquals(3, visitExcludingVoidedSize);
 		
 		handle(newDeleteRequest(getURI() + "/" + getUuid(), new Parameter("reason", "void test reason")));
 		
 		resultWithVoidedVisits = deserialize(handle(newGetRequest(getURI(), new Parameter("patient", patientUUid),
 		    new Parameter("includeAll", "true"))));
 		resultWithoutVoidedVisits = deserialize(handle(newGetRequest(getURI(), new Parameter("patient", patientUUid))));
-		Assert.assertEquals(Util.getResultsSize(resultWithoutVoidedVisits), 2);
-		Assert.assertEquals(Util.getResultsSize(resultWithVoidedVisits), 4);
+		Assert.assertEquals(2, Util.getResultsSize(resultWithoutVoidedVisits));
+		Assert.assertEquals(4, Util.getResultsSize(resultWithVoidedVisits));
 	}
 	
 	@Test
@@ -364,9 +364,9 @@ public class VisitController1_9Test extends MainResourceControllerTest {
 		SimpleObject filteredVisits = deserialize(handle(newGetRequest(getURI(), new Parameter("patient",
 		        patientUUid), new Parameter("visitType", visitTypeUuid))));
 		
-		Assert.assertEquals(Util.getResultsSize(allVisits), 3);
+		Assert.assertEquals(3, Util.getResultsSize(allVisits));
 		int filteredVisitsSize = Util.getResultsSize(filteredVisits);
-		Assert.assertEquals(filteredVisitsSize, 1);
+		Assert.assertEquals(1, filteredVisitsSize);
 		
 	}
 	

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptResource1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptResource1_9Test.java
@@ -92,21 +92,21 @@ public class ConceptResource1_9Test extends BaseDelegatingResourceTest<ConceptRe
 		otherNames.add(otherName);
 		
 		ConceptResource1_8.setNames(instance, otherNames);
-		assertEquals(instance.getNames().size(), 1);
+		assertEquals(1, instance.getNames().size());
 		assertTrue(instance.getNames().contains(otherName));
 		
 		ConceptResource1_8.setNames(instance, getMockNamesList());
-		assertEquals(instance.getNames().size(), 2);
+		assertEquals(2, instance.getNames().size());
 		assertFalse(instance.getNames().contains(otherName));
 		
 		otherNames.addAll(getMockNamesList());
 		
 		ConceptResource1_8.setNames(instance, otherNames);
-		assertEquals(instance.getNames().size(), 3);
+		assertEquals(3, instance.getNames().size());
 		assertTrue(instance.getNames().contains(otherName));
 		
 		ConceptResource1_8.setNames(instance, getMockNamesList());
-		assertEquals(instance.getNames().size(), 2);
+		assertEquals(2, instance.getNames().size());
 		assertFalse(instance.getNames().contains(otherName));
 	}
 	

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/PatientAllergyController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/PatientAllergyController2_0Test.java
@@ -127,7 +127,7 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		Allergy allergy = Context.getPatientService().getAllergyByUuid(getUuid());
 		Patient patient = allergy.getPatient();
 		Allergies allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 4);
+		Assert.assertEquals(4, allergies.size());
 		
 		// save allergy with coded allergen
 		String json = "{" + " \"comment\" : \"allergy comment\","
@@ -147,7 +147,7 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		
 		// assert that a new allergy has been added
 		allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 5);
+		Assert.assertEquals(5, allergies.size());
 	}
 	
 	/**
@@ -158,7 +158,7 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		Allergy allergy = Context.getPatientService().getAllergyByUuid(getUuid());
 		Patient patient = allergy.getPatient();
 		Allergies allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 4);
+		Assert.assertEquals(4, allergies.size());
 		
 		// save allergy with non coded allergen
 		String json = "{" + " \"comment\" : \"allergy comment\","
@@ -180,7 +180,7 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		
 		// assert that a new allergy has been added
 		allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 5);
+		Assert.assertEquals(5, allergies.size());
 	}
 	
 	/**
@@ -191,7 +191,7 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		Allergy allergy = Context.getPatientService().getAllergyByUuid(getUuid());
 		Patient patient = allergy.getPatient();
 		Allergies allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 4);
+		Assert.assertEquals(4, allergies.size());
 		
 		// update allergy with reactions
 		String json = "{ \"reactions\" : " + "[" + "{" + " \"allergy\" : { \"uuid\" : \"" + allergy.getUuid() + "\"},"
@@ -210,7 +210,7 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		
 		// assert that a allergy has been updated
 		allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 4);
+		Assert.assertEquals(4, allergies.size());
 	}
 	
 	/**
@@ -279,7 +279,7 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		Allergy allergy = Context.getPatientService().getAllergyByUuid(getUuid());
 		Patient patient = allergy.getPatient();
 		Allergies allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 4);
+		Assert.assertEquals(4, allergies.size());
 		
 		// save allergy with coded allergen
 		String json = "{" + " \"comment\" : \"allergy comment\","
@@ -311,6 +311,6 @@ public class PatientAllergyController2_0Test extends MainResourceControllerTest 
 		
 		// assert that a new allergy has been added
 		allergies = Context.getPatientService().getAllergies(patient);
-		Assert.assertEquals(allergies.size(), 5);
+		Assert.assertEquals(5, allergies.size());
 	}
 }

--- a/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_2/DiagnosisController2_2Test.java
+++ b/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_2/DiagnosisController2_2Test.java
@@ -256,10 +256,10 @@ public class DiagnosisController2_2Test extends MainResourceControllerTest {
 		
 		Assert.assertFalse(diagnosis.getVoided());
 		Assert.assertNull(diagnosis.getDiagnosis().getCoded());
-		Assert.assertEquals((int) diagnosis.getRank(), 2);
-		Assert.assertEquals(diagnosis.getCertainty().toString(), "CONFIRMED");
-		Assert.assertEquals(diagnosis.getCondition().getUuid(), "e804ee60-ecbc-4d70-abda-1e4f6f64e5b5");
-		Assert.assertEquals(diagnosis.getEncounter().getUuid(), "34444-fcdb-4a5b-97ea-0d5c4b4315a1");
+		Assert.assertEquals(2, (int) diagnosis.getRank());
+		Assert.assertEquals("CONFIRMED", diagnosis.getCertainty().toString());
+		Assert.assertEquals("e804ee60-ecbc-4d70-abda-1e4f6f64e5b5", diagnosis.getCondition().getUuid());
+		Assert.assertEquals("34444-fcdb-4a5b-97ea-0d5c4b4315a1", diagnosis.getEncounter().getUuid());
 		
 		String json = "{\"diagnosis\":{\"coded\":\"" + concept.getUuid() + "\",\"specificName\":\"" + conceptName.getUuid()
 		        + "\"},\"condition\":\"" + condition.getUuid()
@@ -274,10 +274,10 @@ public class DiagnosisController2_2Test extends MainResourceControllerTest {
 		
 		Assert.assertTrue(newDiagnosis.getVoided());
 		Assert.assertEquals(newDiagnosis.getDiagnosis().getCoded().getUuid(), concept.getUuid());
-		Assert.assertEquals((int) newDiagnosis.getRank(), 1);
-		Assert.assertEquals(newDiagnosis.getCondition().getUuid(), condition.getUuid());
-		Assert.assertEquals(newDiagnosis.getCertainty().toString(), "PROVISIONAL");
-		Assert.assertEquals(newDiagnosis.getEncounter().getUuid(), encounter.getUuid());
+		Assert.assertEquals(1, (int) newDiagnosis.getRank());
+		Assert.assertEquals(condition.getUuid(), newDiagnosis.getCondition().getUuid());
+		Assert.assertEquals("PROVISIONAL", newDiagnosis.getCertainty().toString());
+		Assert.assertEquals(encounter.getUuid(), newDiagnosis.getEncounter().getUuid());
 	}
 	
 	@Test
@@ -288,10 +288,10 @@ public class DiagnosisController2_2Test extends MainResourceControllerTest {
 		
 		Assert.assertTrue(diagnosis.getVoided());
 		Assert.assertNull(diagnosis.getDiagnosis().getNonCoded());
-		Assert.assertEquals((int) diagnosis.getRank(), 1);
-		Assert.assertEquals(diagnosis.getCondition().getUuid(), "e804ee60-ecbc-4d70-abda-1e4f6f64e5b5");
-		Assert.assertEquals(diagnosis.getEncounter().getUuid(), "54444-fcdb-4a5b-97ea-0d5c4b4315a1");
-		Assert.assertEquals(diagnosis.getCertainty().toString(), "PROVISIONAL");
+		Assert.assertEquals(1, (int) diagnosis.getRank());
+		Assert.assertEquals("e804ee60-ecbc-4d70-abda-1e4f6f64e5b5", diagnosis.getCondition().getUuid());
+		Assert.assertEquals("54444-fcdb-4a5b-97ea-0d5c4b4315a1", diagnosis.getEncounter().getUuid());
+		Assert.assertEquals("PROVISIONAL", diagnosis.getCertainty().toString());
 		
 		String json = "{ \"diagnosis\":{\"coded\":null,\"specificName\":null,\"nonCoded\":\"" + nonCoded
 		        + "\"},\"condition\":\"" + condition.getUuid()
@@ -304,11 +304,11 @@ public class DiagnosisController2_2Test extends MainResourceControllerTest {
 		Diagnosis newDiagnosis = diagnosisService.getDiagnosisByUuid(RestTestConstants2_2.UPDATABLE_CODED_DIAGNOSIS_UUID);
 		
 		Assert.assertFalse(newDiagnosis.getVoided());
-		Assert.assertEquals(newDiagnosis.getDiagnosis().getNonCoded(), "Some condition");
-		Assert.assertEquals((int) newDiagnosis.getRank(), 2);
-		Assert.assertEquals(newDiagnosis.getCondition().getUuid(), condition.getUuid());
-		Assert.assertEquals(newDiagnosis.getCertainty().toString(), "CONFIRMED");
-		Assert.assertEquals(newDiagnosis.getEncounter().getUuid(), encounter.getUuid());
+		Assert.assertEquals("Some condition", newDiagnosis.getDiagnosis().getNonCoded());
+		Assert.assertEquals(2, (int) newDiagnosis.getRank());
+		Assert.assertEquals(condition.getUuid(), newDiagnosis.getCondition().getUuid());
+		Assert.assertEquals("CONFIRMED", newDiagnosis.getCertainty().toString());
+		Assert.assertEquals(encounter.getUuid(), newDiagnosis.getEncounter().getUuid());
 	}
 	
 	@Test

--- a/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_2/DiagnosisController2_2Test.java
+++ b/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_2/DiagnosisController2_2Test.java
@@ -273,7 +273,7 @@ public class DiagnosisController2_2Test extends MainResourceControllerTest {
 		        .getDiagnosisByUuid(RestTestConstants2_2.UPDATABLE_NON_CODED_DIAGNOSIS_UUID);
 		
 		Assert.assertTrue(newDiagnosis.getVoided());
-		Assert.assertEquals(newDiagnosis.getDiagnosis().getCoded().getUuid(), concept.getUuid());
+		Assert.assertEquals(concept.getUuid(), newDiagnosis.getDiagnosis().getCoded().getUuid());
 		Assert.assertEquals(1, (int) newDiagnosis.getRank());
 		Assert.assertEquals(condition.getUuid(), newDiagnosis.getCondition().getUuid());
 		Assert.assertEquals("PROVISIONAL", newDiagnosis.getCertainty().toString());

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/filter/ContentTypeFilterTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/filter/ContentTypeFilterTest.java
@@ -55,7 +55,7 @@ public class ContentTypeFilterTest {
 			req.setRequestURI("/ws/rest/v1/obs");
 			testFilter.doFilter(req, resp, mockChain);
 			
-			Assert.assertEquals(resp.getStatus(), HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
+			Assert.assertEquals(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE, resp.getStatus());
 		}
 	}
 	
@@ -94,7 +94,7 @@ public class ContentTypeFilterTest {
 		req.setMethod("POST");
 		req.setRequestURI("/ws/rest/v1/obs");
 		
-		Assert.assertEquals(req.getContentType(), null);
+		Assert.assertEquals(null, req.getContentType());
 		
 		testFilter.doFilter(req, resp, mockChain);
 		


### PR DESCRIPTION
## Description of what I changed
17 files updated to correct order of arguments in Assert.assertequals statement.

## Issue I worked on
https://issues.openmrs.org/browse/RESTWS-800

## Checklist: I completed these to help reviewers :)
[x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

[x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

[ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

[x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

[x ] All new and existing **tests passed**.

[x ] My pull request is **based on the latest changes** of the master branch.

