### PR TITLE
RESTWS-821: Add REST resource with links to administration pages of installed modules

### DIFF
--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/MockModuleFactoryWrapper.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/MockModuleFactoryWrapper.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.webservices.rest.web;
 
+import org.openmrs.module.Extension;
 import org.openmrs.module.Module;
 import org.openmrs.module.webservices.helper.ModuleFactoryWrapper;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,7 +25,9 @@ import java.util.List;
 public class MockModuleFactoryWrapper extends ModuleFactoryWrapper {
 	
 	public List<Module> loadedModules = new ArrayList<Module>();
-	
+
+	public List<Extension> loadedExtensions = new ArrayList<Extension>();
+
 	public List<Module> startedModules = new ArrayList<Module>();
 	
 	public Module loadModuleMock;
@@ -53,7 +56,18 @@ public class MockModuleFactoryWrapper extends ModuleFactoryWrapper {
 	public Collection<Module> getLoadedModules() {
 		return loadedModules;
 	}
-	
+
+	@Override
+	public List<Extension> getExtensions(String pointId) {
+		List<Extension> foundExtensions = new ArrayList<Extension>();
+		for (Extension loadedExtension : loadedExtensions) {
+			if (loadedExtension.getPointId().equals(pointId)) {
+				foundExtensions.add(loadedExtension);
+			}
+		}
+		return foundExtensions;
+	}
+
 	@Override
 	public boolean isModuleStarted(Module module) {
 		return startedModules.contains(module);

--- a/omod-2.0/pom.xml
+++ b/omod-2.0/pom.xml
@@ -142,6 +142,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>legacyui-omod</artifactId>
+			<version>1.8.3</version>
+			<scope>provided</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
@@ -54,6 +54,8 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 
 	private ModuleFactoryWrapper moduleFactoryWrapper = new ModuleFactoryWrapper();
 
+	private MessageSourceService messageSourceService = Context.getMessageSourceService();
+
 	@Override
 	public AdministrationSectionLinks newDelegate() {
 		return null;
@@ -162,7 +164,6 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 	}
 
 	private AdministrationSectionLinks mapAdminListExtension(Extension extension) {
-		MessageSourceService messageSourceService = Context.getMessageSourceService();
 		AdministrationSectionExt adminListExtension = (AdministrationSectionExt) extension;
 
 		// map module title message key to its value

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
@@ -1,0 +1,184 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.StringProperty;
+import org.openmrs.api.context.Context;
+import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.module.Extension;
+import org.openmrs.module.web.extension.AdministrationSectionExt;
+import org.openmrs.module.webservices.helper.ModuleFactoryWrapper;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingReadableResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks2_0;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Resource(name = RestConstants.VERSION_1 + "/administrationlinks", supportedClass = AdministrationSectionLinks2_0.class,
+		supportedOpenmrsVersions = { "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*", "2.5.*" })
+public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResource<AdministrationSectionLinks2_0> {
+
+	private static final String UUID = "uuid";
+
+	private static final String DISPLAY = "display";
+
+	private static final String ADMIN_LIST_POINT_ID = "org.openmrs.admin.list";
+
+	private static final String MODULE_TITLE = "title";
+
+	private static final String LINKS = "administrationLinks";
+
+	private ModuleFactoryWrapper moduleFactoryWrapper = new ModuleFactoryWrapper();
+
+	@Override
+	public AdministrationSectionLinks2_0 newDelegate() {
+		return null;
+	}
+
+	@Override
+	public AdministrationSectionLinks2_0 getByUniqueId(String moduleId) {
+		// Assumes that moduleId is an id of a module that user wants to get admin links for.
+		// AdministrationLinksResource has no id by itself as it's not an OpenMRS data object.
+
+		AdministrationSectionLinks2_0 administrationLinks = getAdministrationLinksForModule(moduleId);
+		if (administrationLinks == null) {
+			throw new ObjectNotFoundException(
+					"Module with id: " + moduleId + " doesn't have any administration links registered.");
+		}
+
+		return administrationLinks;
+	}
+
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		if (rep instanceof DefaultRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty(UUID);
+			description.addProperty(DISPLAY);
+			description.addProperty(MODULE_TITLE);
+			description.addProperty(LINKS);
+			description.addSelfLink();
+			return description;
+		} else if (rep instanceof FullRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty(UUID);
+			description.addProperty(DISPLAY);
+			description.addProperty(MODULE_TITLE);
+			description.addProperty(LINKS);
+			description.addSelfLink();
+			return description;
+		} else if (rep instanceof RefRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty(UUID);
+			description.addProperty(DISPLAY);
+			description.addProperty(MODULE_TITLE);
+			description.addProperty(LINKS);
+			description.addSelfLink();
+			return description;
+		}
+		return null;
+	}
+
+	@PropertyGetter("uuid")
+	public static String getUuid(AdministrationSectionLinks2_0 instance) {
+		return instance.getModuleId();
+	}
+
+	@PropertyGetter("display")
+	public static String getDisplay(AdministrationSectionLinks2_0 instance) {
+		return instance.getTitle();
+	}
+
+	@PropertyGetter(LINKS)
+	public static Map<String, String> getLinks(AdministrationSectionLinks2_0 instance) {
+		return instance.getLinks();
+	}
+
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
+			model
+					.property(MODULE_TITLE, new StringProperty())
+					.property(LINKS, new ArrayProperty(new ObjectProperty()));
+		}
+
+		return model;
+	}
+
+	@Override
+	public NeedsPaging<AdministrationSectionLinks2_0> doGetAll(RequestContext context) throws ResponseException {
+		return new NeedsPaging<>(getAllAdministrationLinks(), context);
+	}
+
+	private AdministrationSectionLinks2_0 getAdministrationLinksForModule(String moduleId) {
+		List<Extension> adminListsExtensions = moduleFactoryWrapper.getExtensions(ADMIN_LIST_POINT_ID);
+		for (Extension adminListExtension : adminListsExtensions) {
+			if (adminListExtension instanceof AdministrationSectionExt && adminListExtension.getModuleId()
+					.equals(moduleId)) {
+				return mapAdminListExtension(adminListExtension);
+			}
+		}
+
+		return null;
+	}
+
+	private List<AdministrationSectionLinks2_0> getAllAdministrationLinks() {
+		List<AdministrationSectionLinks2_0> modulesWithLinksList = new ArrayList<>();
+
+		List<Extension> adminListsExtensions = moduleFactoryWrapper.getExtensions(ADMIN_LIST_POINT_ID);
+
+		for (Extension adminListExtension : adminListsExtensions) {
+			if (adminListExtension instanceof AdministrationSectionExt) {
+				modulesWithLinksList.add(mapAdminListExtension(adminListExtension));
+			}
+		}
+
+		return modulesWithLinksList;
+	}
+
+	private AdministrationSectionLinks2_0 mapAdminListExtension(Extension extension) {
+		MessageSourceService messageSourceService = Context.getMessageSourceService();
+		AdministrationSectionExt adminListExtension = (AdministrationSectionExt) extension;
+
+		// map module title message key to its value
+		String title = messageSourceService.getMessage(adminListExtension.getTitle());
+
+		// map link titles to their values
+		Map<String, String> links = adminListExtension.getLinks();
+		for (Map.Entry<String, String> link : links.entrySet()) {
+			link.setValue(messageSourceService.getMessage(link.getValue()));
+		}
+
+		AdministrationSectionLinks2_0 administrationSectionLinks = new AdministrationSectionLinks2_0();
+		administrationSectionLinks.setModuleId(adminListExtension.getModuleId());
+		administrationSectionLinks.setTitle(title);
+		administrationSectionLinks.setLinks(links);
+
+		return administrationSectionLinks;
+	}
+}

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
@@ -54,8 +54,6 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 
 	private ModuleFactoryWrapper moduleFactoryWrapper = new ModuleFactoryWrapper();
 
-	private MessageSourceService messageSourceService = Context.getMessageSourceService();
-
 	@Override
 	public AdministrationSectionLinks newDelegate() {
 		return null;
@@ -138,11 +136,14 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 	}
 
 	private AdministrationSectionLinks getAdministrationLinksForModule(String moduleId) {
+		MessageSourceService messageSourceService = Context.getMessageSourceService();
+
 		List<Extension> adminListsExtensions = moduleFactoryWrapper.getExtensions(ADMIN_LIST_POINT_ID);
+
 		for (Extension adminListExtension : adminListsExtensions) {
 			if (adminListExtension instanceof AdministrationSectionExt && adminListExtension.getModuleId()
 					.equals(moduleId)) {
-				return mapAdminListExtension(adminListExtension);
+				return mapAdminListExtension(adminListExtension, messageSourceService);
 			}
 		}
 
@@ -150,20 +151,22 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 	}
 
 	private List<AdministrationSectionLinks> getAllAdministrationLinks() {
+		MessageSourceService messageSourceService = Context.getMessageSourceService();
 		List<AdministrationSectionLinks> modulesWithLinksList = new ArrayList<>();
 
 		List<Extension> adminListsExtensions = moduleFactoryWrapper.getExtensions(ADMIN_LIST_POINT_ID);
 
 		for (Extension adminListExtension : adminListsExtensions) {
 			if (adminListExtension instanceof AdministrationSectionExt) {
-				modulesWithLinksList.add(mapAdminListExtension(adminListExtension));
+				modulesWithLinksList.add(mapAdminListExtension(adminListExtension, messageSourceService));
 			}
 		}
 
 		return modulesWithLinksList;
 	}
 
-	private AdministrationSectionLinks mapAdminListExtension(Extension extension) {
+	private AdministrationSectionLinks mapAdminListExtension(Extension extension,
+			MessageSourceService messageSourceService) {
 		AdministrationSectionExt adminListExtension = (AdministrationSectionExt) extension;
 
 		// map module title message key to its value

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
@@ -103,12 +103,12 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 		return null;
 	}
 
-	@PropertyGetter("uuid")
+	@PropertyGetter(UUID)
 	public static String getUuid(AdministrationSectionLinks2_0 instance) {
 		return instance.getModuleId();
 	}
 
-	@PropertyGetter("display")
+	@PropertyGetter(DISPLAY)
 	public static String getDisplay(AdministrationSectionLinks2_0 instance) {
 		return instance.getTitle();
 	}

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
@@ -32,15 +32,15 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
-import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks2_0;
+import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@Resource(name = RestConstants.VERSION_1 + "/administrationlinks", supportedClass = AdministrationSectionLinks2_0.class,
+@Resource(name = RestConstants.VERSION_1 + "/administrationlinks", supportedClass = AdministrationSectionLinks.class,
 		supportedOpenmrsVersions = { "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*", "2.5.*" })
-public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResource<AdministrationSectionLinks2_0> {
+public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResource<AdministrationSectionLinks> {
 
 	private static final String UUID = "uuid";
 
@@ -55,16 +55,16 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 	private ModuleFactoryWrapper moduleFactoryWrapper = new ModuleFactoryWrapper();
 
 	@Override
-	public AdministrationSectionLinks2_0 newDelegate() {
+	public AdministrationSectionLinks newDelegate() {
 		return null;
 	}
 
 	@Override
-	public AdministrationSectionLinks2_0 getByUniqueId(String moduleId) {
+	public AdministrationSectionLinks getByUniqueId(String moduleId) {
 		// Assumes that moduleId is an id of a module that user wants to get admin links for.
 		// AdministrationLinksResource has no id by itself as it's not an OpenMRS data object.
 
-		AdministrationSectionLinks2_0 administrationLinks = getAdministrationLinksForModule(moduleId);
+		AdministrationSectionLinks administrationLinks = getAdministrationLinksForModule(moduleId);
 		if (administrationLinks == null) {
 			throw new ObjectNotFoundException(
 					"Module with id: " + moduleId + " doesn't have any administration links registered.");
@@ -104,17 +104,17 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 	}
 
 	@PropertyGetter(UUID)
-	public static String getUuid(AdministrationSectionLinks2_0 instance) {
+	public static String getUuid(AdministrationSectionLinks instance) {
 		return instance.getModuleId();
 	}
 
 	@PropertyGetter(DISPLAY)
-	public static String getDisplay(AdministrationSectionLinks2_0 instance) {
+	public static String getDisplay(AdministrationSectionLinks instance) {
 		return instance.getTitle();
 	}
 
 	@PropertyGetter(LINKS)
-	public static Map<String, String> getLinks(AdministrationSectionLinks2_0 instance) {
+	public static Map<String, String> getLinks(AdministrationSectionLinks instance) {
 		return instance.getLinks();
 	}
 
@@ -131,11 +131,11 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 	}
 
 	@Override
-	public NeedsPaging<AdministrationSectionLinks2_0> doGetAll(RequestContext context) throws ResponseException {
+	public NeedsPaging<AdministrationSectionLinks> doGetAll(RequestContext context) throws ResponseException {
 		return new NeedsPaging<>(getAllAdministrationLinks(), context);
 	}
 
-	private AdministrationSectionLinks2_0 getAdministrationLinksForModule(String moduleId) {
+	private AdministrationSectionLinks getAdministrationLinksForModule(String moduleId) {
 		List<Extension> adminListsExtensions = moduleFactoryWrapper.getExtensions(ADMIN_LIST_POINT_ID);
 		for (Extension adminListExtension : adminListsExtensions) {
 			if (adminListExtension instanceof AdministrationSectionExt && adminListExtension.getModuleId()
@@ -147,8 +147,8 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 		return null;
 	}
 
-	private List<AdministrationSectionLinks2_0> getAllAdministrationLinks() {
-		List<AdministrationSectionLinks2_0> modulesWithLinksList = new ArrayList<>();
+	private List<AdministrationSectionLinks> getAllAdministrationLinks() {
+		List<AdministrationSectionLinks> modulesWithLinksList = new ArrayList<>();
 
 		List<Extension> adminListsExtensions = moduleFactoryWrapper.getExtensions(ADMIN_LIST_POINT_ID);
 
@@ -161,7 +161,7 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 		return modulesWithLinksList;
 	}
 
-	private AdministrationSectionLinks2_0 mapAdminListExtension(Extension extension) {
+	private AdministrationSectionLinks mapAdminListExtension(Extension extension) {
 		MessageSourceService messageSourceService = Context.getMessageSourceService();
 		AdministrationSectionExt adminListExtension = (AdministrationSectionExt) extension;
 
@@ -174,7 +174,7 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 			link.setValue(messageSourceService.getMessage(link.getValue()));
 		}
 
-		AdministrationSectionLinks2_0 administrationSectionLinks = new AdministrationSectionLinks2_0();
+		AdministrationSectionLinks administrationSectionLinks = new AdministrationSectionLinks();
 		administrationSectionLinks.setModuleId(adminListExtension.getModuleId());
 		administrationSectionLinks.setTitle(title);
 		administrationSectionLinks.setLinks(links);

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/wrapper/AdministrationSectionLinks.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/wrapper/AdministrationSectionLinks.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * - Using a custom wrapper gives us more flexibility when {@link AdministrationSectionExt}
  * would change in the future.
  */
-public class AdministrationSectionLinks2_0 {
+public class AdministrationSectionLinks {
 
 	private String moduleId;
 
@@ -32,10 +32,10 @@ public class AdministrationSectionLinks2_0 {
 
 	private Map<String, String> links;
 
-	public AdministrationSectionLinks2_0() {
+	public AdministrationSectionLinks() {
 	}
 
-	public AdministrationSectionLinks2_0(String moduleId, String title, Map<String, String> links) {
+	public AdministrationSectionLinks(String moduleId, String title, Map<String, String> links) {
 		this.moduleId = moduleId;
 		this.title = title;
 		this.links = links;

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/wrapper/AdministrationSectionLinks2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/wrapper/AdministrationSectionLinks2_0.java
@@ -1,0 +1,59 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.wrapper;
+
+import org.openmrs.module.web.extension.AdministrationSectionExt;
+
+import java.util.Map;
+
+/**
+ * REST wrapper for {@link AdministrationSectionExt}
+ */
+public class AdministrationSectionLinks2_0 {
+
+	private String moduleId;
+
+	private String title;
+
+	private Map<String, String> links;
+
+	public AdministrationSectionLinks2_0() {
+	}
+
+	public AdministrationSectionLinks2_0(String moduleId, String title, Map<String, String> links) {
+		this.moduleId = moduleId;
+		this.title = title;
+		this.links = links;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public Map<String, String> getLinks() {
+		return links;
+	}
+
+	public void setLinks(Map<String, String> links) {
+		this.links = links;
+	}
+
+	public String getModuleId() {
+		return moduleId;
+	}
+
+	public void setModuleId(String moduleId) {
+		this.moduleId = moduleId;
+	}
+}

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/wrapper/AdministrationSectionLinks2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/wrapper/AdministrationSectionLinks2_0.java
@@ -15,6 +15,14 @@ import java.util.Map;
 
 /**
  * REST wrapper for {@link AdministrationSectionExt}
+ * We're using it instead of {@link AdministrationSectionExt} for a few reasons:
+ * - {@link AdministrationSectionExt} class doesn't support setters for its fields
+ * so we cannot map their values, for example as we do with message keys.
+ * - Using {@link AdministrationSectionExt} as a Resource requires all Resource classes
+ * to have this class on their classpath, resulting in requirement to add legacyui-omod
+ * dependency to each module
+ * - Using a custom wrapper gives us more flexibility when {@link AdministrationSectionExt}
+ * would change in the future.
  */
 public class AdministrationSectionLinks2_0 {
 

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/AdministrationLinksController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/AdministrationLinksController2_0Test.java
@@ -102,7 +102,7 @@ public class AdministrationLinksController2_0Test extends MainResourceController
 
 	private void assertCorrectAtlasModuleLinks(Object result)
 			throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-		assertEquals("openconceptlab", PropertyUtils.getProperty(result, "uuid"));
+		assertEquals("atlas", PropertyUtils.getProperty(result, "uuid"));
 		assertEquals("Atlas-links", PropertyUtils.getProperty(result, "title"));
 
 		Object links = PropertyUtils.getProperty(result, "administrationLinks");
@@ -154,7 +154,7 @@ public class AdministrationLinksController2_0Test extends MainResourceController
 				return "org.openmrs.admin.list";
 			}
 		};
-		extension.setModuleId("openconceptlab");
+		extension.setModuleId("atlas");
 		mockModuleFactory.loadedExtensions.add(extension);
 	}
 }

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/AdministrationLinksController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/AdministrationLinksController2_0Test.java
@@ -1,0 +1,160 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.module.Extension;
+import org.openmrs.module.web.extension.AdministrationSectionExt;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.test.Util;
+import org.openmrs.module.webservices.rest.web.MockModuleFactoryWrapper;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.api.RestService;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0.AdministrationLinksResource2_0;
+import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks2_0;
+import org.powermock.reflect.Whitebox;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests Read operations for {@link AdministrationSectionExt} via web service calls
+ */
+public class AdministrationLinksController2_0Test extends MainResourceControllerTest {
+
+	@Autowired
+	RestService restService;
+
+	MockModuleFactoryWrapper mockModuleFactory = new MockModuleFactoryWrapper();
+
+	@Before
+	public void setUp() throws Exception {
+		setupMockRestWsModuleAdminListExtension();
+		setupMockAtlasModuleAdminListExtension();
+
+		AdministrationLinksResource2_0 administrationLinksResource = (AdministrationLinksResource2_0) restService
+				.getResourceBySupportedClass(AdministrationSectionLinks2_0.class);
+
+		Whitebox.setInternalState(administrationLinksResource, "moduleFactoryWrapper", mockModuleFactory);
+	}
+
+	@Override
+	public String getURI() {
+		return "administrationlinks";
+	}
+
+	@Override
+	public String getUuid() {
+		return RestConstants.MODULE_ID;
+	}
+
+	@Override
+	public long getAllCount() {
+		return 2;
+	}
+
+	@Test
+	public void shouldReturnListOfLinksForInstalledModules() throws Exception {
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+		SimpleObject result = deserialize(handle(req));
+
+		assertEquals(2, Util.getResultsSize(result));
+
+		List<Object> results = Util.getResultsList(result);
+		assertCorrectWsModuleLinks(results.get(0));
+		assertCorrectAtlasModuleLinks(results.get(1));
+	}
+
+	@Test
+	public void shouldReturnListOfLinksForOneModuleByUuid() throws Exception {
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI() + "/" + getUuid());
+		SimpleObject result = deserialize(handle(req));
+
+		assertCorrectWsModuleLinks(result);
+	}
+
+	private void assertCorrectWsModuleLinks(Object result)
+			throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+		assertEquals(RestConstants.MODULE_ID, PropertyUtils.getProperty(result, "uuid"));
+		assertEquals("WS-links", PropertyUtils.getProperty(result, "title"));
+
+		Object links = PropertyUtils.getProperty(result, "administrationLinks");
+		assertNotNull(links);
+	}
+
+	private void assertCorrectAtlasModuleLinks(Object result)
+			throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+		assertEquals("openconceptlab", PropertyUtils.getProperty(result, "uuid"));
+		assertEquals("Atlas-links", PropertyUtils.getProperty(result, "title"));
+
+		Object links = PropertyUtils.getProperty(result, "administrationLinks");
+		assertNotNull(links);
+	}
+
+	private void setupMockRestWsModuleAdminListExtension() {
+		Extension extension = new AdministrationSectionExt() {
+
+			@Override
+			public String getTitle() {
+				return "WS-links";
+			}
+
+			@Override
+			public Map<String, String> getLinks() {
+				Map<String, String> linksMap = new HashMap<>();
+				linksMap.put("link1", "ws.first.link");
+				linksMap.put("link2", "ws.second.link");
+				return linksMap;
+			}
+
+			@Override
+			public String getPointId() {
+				return "org.openmrs.admin.list";
+			}
+		};
+		extension.setModuleId(RestConstants.MODULE_ID);
+		mockModuleFactory.loadedExtensions.add(extension);
+	}
+
+	private void setupMockAtlasModuleAdminListExtension() {
+		Extension extension = new AdministrationSectionExt() {
+
+			@Override
+			public String getTitle() {
+				return "Atlas-links";
+			}
+
+			@Override
+			public Map<String, String> getLinks() {
+				Map<String, String> linksMap = new HashMap<>();
+				linksMap.put("link3", "atlas.first.link");
+				return linksMap;
+			}
+
+			@Override
+			public String getPointId() {
+				return "org.openmrs.admin.list";
+			}
+		};
+		extension.setModuleId("openconceptlab");
+		mockModuleFactory.loadedExtensions.add(extension);
+	}
+}

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/AdministrationLinksController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/AdministrationLinksController2_0Test.java
@@ -21,7 +21,7 @@ import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0.AdministrationLinksResource2_0;
-import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks2_0;
+import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks;
 import org.powermock.reflect.Whitebox;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -51,7 +51,7 @@ public class AdministrationLinksController2_0Test extends MainResourceController
 		setupMockAtlasModuleAdminListExtension();
 
 		AdministrationLinksResource2_0 administrationLinksResource = (AdministrationLinksResource2_0) restService
-				.getResourceBySupportedClass(AdministrationSectionLinks2_0.class);
+				.getResourceBySupportedClass(AdministrationSectionLinks.class);
 
 		Whitebox.setInternalState(administrationLinksResource, "moduleFactoryWrapper", mockModuleFactory);
 	}

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0Test.java
@@ -11,20 +11,20 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
 
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks2_0;
+import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class AdministrationLinksResource2_0Test
-		extends BaseDelegatingResourceTest<AdministrationLinksResource2_0, AdministrationSectionLinks2_0> {
+		extends BaseDelegatingResourceTest<AdministrationLinksResource2_0, AdministrationSectionLinks> {
 
 	@Override
-	public AdministrationSectionLinks2_0 newObject() {
+	public AdministrationSectionLinks newObject() {
 		Map<String, String> links = new HashMap<>();
 		links.put("module/webservices/rest/settings.form", RestConstants.MODULE_ID + ".manage.settings");
 
-		return new AdministrationSectionLinks2_0(RestConstants.MODULE_ID,
+		return new AdministrationSectionLinks(RestConstants.MODULE_ID,
 				RestConstants.MODULE_ID + ".title", links);
 	}
 

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0Test.java
@@ -1,0 +1,40 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
+import org.openmrs.module.webservices.rest.web.v1_0.wrapper.AdministrationSectionLinks2_0;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AdministrationLinksResource2_0Test
+		extends BaseDelegatingResourceTest<AdministrationLinksResource2_0, AdministrationSectionLinks2_0> {
+
+	@Override
+	public AdministrationSectionLinks2_0 newObject() {
+		Map<String, String> links = new HashMap<>();
+		links.put("module/webservices/rest/settings.form", RestConstants.MODULE_ID + ".manage.settings");
+
+		return new AdministrationSectionLinks2_0(RestConstants.MODULE_ID,
+				RestConstants.MODULE_ID + ".title", links);
+	}
+
+	@Override
+	public String getDisplayProperty() {
+		return RestConstants.MODULE_ID + ".title";
+	}
+
+	@Override
+	public String getUuidProperty() {
+		return RestConstants.MODULE_ID;
+	}
+}

--- a/omod-common/src/main/java/org/openmrs/module/webservices/helper/ModuleFactoryWrapper.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/helper/ModuleFactoryWrapper.java
@@ -11,6 +11,7 @@ package org.openmrs.module.webservices.helper;
 
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.Extension;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.ModuleFileParser;
@@ -51,6 +52,10 @@ public class ModuleFactoryWrapper {
 	
 	public Collection<Module> getLoadedModules() {
 		return ModuleFactory.getLoadedModules();
+	}
+
+	public List<Extension> getExtensions(String pointId) {
+		return ModuleFactory.getExtensions(pointId);
 	}
 	
 	public boolean isModuleStarted(Module module) {

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/response/ObjectNotFoundException.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/response/ObjectNotFoundException.java
@@ -24,4 +24,8 @@ public class ObjectNotFoundException extends ResponseException {
 	public ObjectNotFoundException() {
 		
 	}
+
+	public ObjectNotFoundException(String message) {
+		super(message);
+	}
 }


### PR DESCRIPTION
## Description of what I changed
Added REST resource with links to administration pages of installed modules.

It can return a list of all administration links for installed modules at `/openmrs/ws/rest/v1/administration-links/`.
It can also return list of administration links for given module id at `/openmrs/ws/rest/v1/administration-links/{moduleId}`.

Example response body can be found here: [https://pastebin.com/q2deZqaL](https://pastebin.com/q2deZqaL)

PR with documentation: [https://github.com/openmrs/openmrs-contrib-rest-api-docs/pull/140](https://github.com/openmrs/openmrs-contrib-rest-api-docs/pull/140)

To not rely on LegacyUI, I've copied AdministrationSectionExt from [https://github.com/openmrs/openmrs-module-legacyui/blob/master/omod/src/main/java/org/openmrs/module/web/extension/AdministrationSectionExt.java](https://github.com/openmrs/openmrs-module-legacyui/blob/master/omod/src/main/java/org/openmrs/module/web/extension/AdministrationSectionExt.java) into `omod-common` module. I'm wondering if that's a good solution though. If I didn't include this class, the `SwaggerSpecificationCreatorTest` test would fail with `NoClassDefFoundError`. @dkayiwa What do you think I should do with this? Fix the test and not include the Ext class or just leave it like right now?

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-821

## Checklist: I completed these to help reviewers :)
- [X] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

