### PR TITLE
RESTWS-834: Add REST resource for Database Changes

### DIFF
--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
@@ -27,6 +27,7 @@ import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingReadableResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.GenericRestException;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.util.DatabaseUpdater;
 
@@ -153,8 +154,7 @@ public class DatabaseChangeResource2_0 extends BaseDelegatingReadableResource<Da
 			databaseChanges = DatabaseUpdater.getDatabaseChanges();
 		}
 		catch (Exception e) {
-			e.printStackTrace();
-			databaseChanges = new ArrayList<>();
+			throw new GenericRestException("Exception while getting database changes", e);
 		}
 		return databaseChanges;
 	}

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
@@ -1,0 +1,167 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.StringProperty;
+import liquibase.changelog.ChangeSet;
+import org.openmrs.module.webservices.docs.swagger.core.property.EnumProperty;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingReadableResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.util.DatabaseUpdater;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link Resource} for {@link DatabaseUpdater.OpenMRSChangeSet}, supporting Read operation.
+ */
+@Resource(name = RestConstants.VERSION_1
+		+ "/databasechange", supportedClass = DatabaseUpdater.OpenMRSChangeSet.class, supportedOpenmrsVersions = {
+		"2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*", "2.5.*" })
+public class DatabaseChangeResource2_0 extends BaseDelegatingReadableResource<DatabaseUpdater.OpenMRSChangeSet> {
+
+	private static final String UUID = "uuid";
+
+	private static final String DISPLAY = "display";
+
+	private static final String AUTHOR = "author";
+
+	private static final String COMMENTS = "comments";
+
+	private static final String DESCRIPTION = "description";
+
+	private static final String RUN_STATUS = "runStatus";
+
+	private static final String RAN_DATE = "ranDate";
+
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		if (rep instanceof DefaultRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty(UUID);
+			description.addProperty(DISPLAY);
+			description.addProperty(AUTHOR);
+			description.addProperty(DESCRIPTION);
+			description.addProperty(RUN_STATUS);
+			description.addSelfLink();
+			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+			return description;
+		} else if (rep instanceof FullRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty(UUID);
+			description.addProperty(DISPLAY);
+			description.addProperty(AUTHOR);
+			description.addProperty(DESCRIPTION);
+			description.addProperty(RUN_STATUS);
+			description.addProperty(COMMENTS);
+			description.addProperty(RAN_DATE);
+			description.addSelfLink();
+			return description;
+		} else if (rep instanceof RefRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty(UUID);
+			description.addProperty(DISPLAY);
+			description.addSelfLink();
+			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+			return description;
+		}
+		return null;
+	}
+
+	@Override
+	public PageableResult doGetAll(RequestContext context) {
+		return new NeedsPaging<>(getDatabaseChanges(), context);
+	}
+
+	@Override
+	public DatabaseUpdater.OpenMRSChangeSet getByUniqueId(String uniqueId) {
+		DatabaseUpdater.OpenMRSChangeSet databaseChange = getDatabaseChangeById(uniqueId);
+
+		if (databaseChange == null) {
+			throw new ObjectNotFoundException("Database change with id: " + uniqueId + " doesn't exist.");
+		}
+
+		return databaseChange;
+	}
+
+	@PropertyGetter(UUID)
+	public static String getUuid(DatabaseUpdater.OpenMRSChangeSet instance) {
+		return instance.getId();
+	}
+
+	@PropertyGetter(DISPLAY)
+	public static String getDisplay(DatabaseUpdater.OpenMRSChangeSet instance) {
+		return instance.getAuthor() + " " + instance.getDescription();
+	}
+
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+					.property(UUID, new StringProperty())
+					.property(DISPLAY, new StringProperty())
+					.property(AUTHOR, new StringProperty())
+					.property(DESCRIPTION, new StringProperty())
+					.property(RUN_STATUS, new EnumProperty(ChangeSet.RunStatus.class));
+		} else if (rep instanceof FullRepresentation) {
+			model
+					.property(UUID, new StringProperty())
+					.property(DISPLAY, new StringProperty())
+					.property(AUTHOR, new StringProperty())
+					.property(DESCRIPTION, new StringProperty())
+					.property(RUN_STATUS, new EnumProperty(ChangeSet.RunStatus.class))
+					.property(COMMENTS, new StringProperty())
+					.property(RAN_DATE, new DateProperty());
+		} else if (rep instanceof RefRepresentation) {
+			model
+					.property(UUID, new StringProperty())
+					.property(DISPLAY, new StringProperty());
+		}
+		return model;
+	}
+
+	@Override
+	public DatabaseUpdater.OpenMRSChangeSet newDelegate() {
+		return null;
+	}
+
+	private List<DatabaseUpdater.OpenMRSChangeSet> getDatabaseChanges() {
+		List<DatabaseUpdater.OpenMRSChangeSet> databaseChanges;
+		try {
+			databaseChanges = DatabaseUpdater.getDatabaseChanges();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			databaseChanges = new ArrayList<>();
+		}
+		return databaseChanges;
+	}
+
+	private DatabaseUpdater.OpenMRSChangeSet getDatabaseChangeById(String id) {
+		return getDatabaseChanges().stream().filter(e -> e.getId().equals(id)).findFirst().orElse(null);
+	}
+}
+
+

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/DatabaseChangeController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/DatabaseChangeController2_0Test.java
@@ -1,0 +1,41 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
+
+import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.openmrs.util.DatabaseUpdater;
+
+public class DatabaseChangeController2_0Test extends MainResourceControllerTest {
+
+	@Override
+	public String getURI() {
+		return "databasechange";
+	}
+
+	@Override
+	public String getUuid() {
+		try {
+			return DatabaseUpdater.getDatabaseChanges().get(0).getId();
+		}
+		catch (Exception e) {
+			return null;
+		}
+	}
+
+	@Override
+	public long getAllCount() {
+		try {
+			return Math.min(DatabaseUpdater.getDatabaseChanges().size(), 50); // page is max 50
+		}
+		catch (Exception e) {
+			return 0;
+		}
+	}
+}

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0Test.java
@@ -1,0 +1,43 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+
+import org.mockito.Mockito;
+import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
+import org.openmrs.util.DatabaseUpdater;
+
+import java.util.Date;
+
+import static liquibase.changelog.ChangeSet.RunStatus.ALREADY_RAN;
+
+public class DatabaseChangeResource2_0Test extends BaseDelegatingResourceTest<DatabaseChangeResource2_0, DatabaseUpdater.OpenMRSChangeSet> {
+
+	@Override
+	public DatabaseUpdater.OpenMRSChangeSet newObject() {
+		DatabaseUpdater.OpenMRSChangeSet changeSet = Mockito.mock(DatabaseUpdater.OpenMRSChangeSet.class, Mockito.CALLS_REAL_METHODS);
+		changeSet.setId("id");
+		changeSet.setAuthor("author");
+		changeSet.setComments("comments");
+		changeSet.setDescription("description");
+		changeSet.setRanDate(new Date(1625683652));
+		changeSet.setRunStatus(ALREADY_RAN);
+		return changeSet;
+	}
+
+	@Override
+	public String getDisplayProperty() {
+		return "author description";
+	}
+
+	@Override
+	public String getUuidProperty() {
+		return "id";
+	}
+}


### PR DESCRIPTION
## Description of what I changed
Added DatabaseChangeResource2_0 that allows listing all OpenMRSChangeSets and listing one by its id.

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-834

PR with documentation: https://github.com/openmrs/openmrs-contrib-rest-api-docs/pull/154

## Checklist: I completed these to help reviewers :)
- [X] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

