### PR TITLE
RESTWS-836: Add REST resource for Triggered State Conversions management

### DIFF
--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
@@ -33,7 +33,7 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 /**
  * {@link Resource} for {@link ConceptStateConversion}, supporting standard CRUD operations
  */
-@Resource(name = RestConstants.VERSION_1 + "/stateconversion", supportedClass = ConceptStateConversion.class,
+@Resource(name = RestConstants.VERSION_1 + "/conceptstateconversion", supportedClass = ConceptStateConversion.class,
 		supportedOpenmrsVersions = { "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*", "2.5.*" })
 public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<ConceptStateConversion> {
 

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
@@ -17,6 +17,7 @@ import org.openmrs.ConceptStateConversion;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
@@ -42,6 +43,7 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 		if (rep instanceof DefaultRepresentation) {
 			DelegatingResourceDescription description = new DelegatingResourceDescription();
 			description.addProperty("uuid");
+			description.addProperty("display");
 			description.addProperty("concept", Representation.REF);
 			description.addProperty("programWorkflow", Representation.REF);
 			description.addProperty("programWorkflowState", Representation.REF);
@@ -51,6 +53,7 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 		} else if (rep instanceof FullRepresentation) {
 			DelegatingResourceDescription description = new DelegatingResourceDescription();
 			description.addProperty("uuid");
+			description.addProperty("display");
 			description.addProperty("concept", Representation.DEFAULT);
 			description.addProperty("programWorkflow", Representation.DEFAULT);
 			description.addProperty("programWorkflowState", Representation.DEFAULT);
@@ -59,6 +62,7 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 		} else if (rep instanceof RefRepresentation) {
 			DelegatingResourceDescription description = new DelegatingResourceDescription();
 			description.addProperty("uuid");
+			description.addProperty("display");
 			description.addProperty("concept", Representation.REF);
 			description.addProperty("programWorkflow", Representation.REF);
 			description.addProperty("programWorkflowState", Representation.REF);
@@ -67,6 +71,11 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 			return description;
 		}
 		return null;
+	}
+
+	@PropertyGetter("display")
+	public String getDisplayProperty(ConceptStateConversion delegate) {
+		return delegate.toString();
 	}
 
 	@Override

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
@@ -1,0 +1,161 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.RefProperty;
+import org.openmrs.ConceptStateConversion;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.IllegalRequestException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+/**
+ * {@link Resource} for {@link ConceptStateConversion}, supporting standard CRUD operations
+ */
+@Resource(name = RestConstants.VERSION_1 + "/stateconversion", supportedClass = ConceptStateConversion.class,
+		supportedOpenmrsVersions = { "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*", "2.5.*" })
+public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<ConceptStateConversion> {
+
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+		if (rep instanceof DefaultRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty("uuid");
+			description.addProperty("concept", Representation.REF);
+			description.addProperty("programWorkflow", Representation.REF);
+			description.addProperty("programWorkflowState", Representation.REF);
+			description.addSelfLink();
+			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+			return description;
+		} else if (rep instanceof FullRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty("uuid");
+			description.addProperty("concept", Representation.DEFAULT);
+			description.addProperty("programWorkflow", Representation.DEFAULT);
+			description.addProperty("programWorkflowState", Representation.DEFAULT);
+			description.addSelfLink();
+			return description;
+		} else if (rep instanceof RefRepresentation) {
+			DelegatingResourceDescription description = new DelegatingResourceDescription();
+			description.addProperty("uuid");
+			description.addProperty("concept", Representation.REF);
+			description.addProperty("programWorkflow", Representation.REF);
+			description.addProperty("programWorkflowState", Representation.REF);
+			description.addSelfLink();
+			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+			return description;
+		}
+		return null;
+	}
+
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		description.addRequiredProperty("concept");
+		description.addRequiredProperty("programWorkflow");
+		description.addRequiredProperty("programWorkflowState");
+		return description;
+	}
+
+	@Override
+	public Model getGETModel(Representation rep) {
+		ModelImpl model = (ModelImpl) super.getGETModel(rep);
+		if (rep instanceof DefaultRepresentation) {
+			model
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("programWorkflow", new ArrayProperty(new RefProperty("#/definitions/WorkflowGetRef")))
+					.property("programWorkflowState", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateGetRef")));
+		} else if (rep instanceof FullRepresentation) {
+			model
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("programWorkflow", new ArrayProperty(new RefProperty("#/definitions/WorkflowGetRef")))
+					.property("programWorkflowState", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateGetRef")));
+		} else if (rep instanceof RefRepresentation) {
+			model
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("programWorkflow", new ArrayProperty(new RefProperty("#/definitions/WorkflowGetRef")))
+					.property("programWorkflowState", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateGetRef")));
+		}
+		return model;
+	}
+
+	@Override
+	public Model getCREATEModel(Representation rep) {
+		ModelImpl model = new ModelImpl();
+		if (rep instanceof DefaultRepresentation) {
+			model
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("programWorkflow", new ArrayProperty(new RefProperty("#/definitions/WorkflowCreateRef")))
+					.property("programWorkflowState", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateCreateRef")));
+		} else if (rep instanceof FullRepresentation) {
+			model
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("programWorkflow", new ArrayProperty(new RefProperty("#/definitions/WorkflowGet")))
+					.property("programWorkflowState", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateGet")));
+		} else if (rep instanceof RefRepresentation) {
+			model
+					.property("concept", new RefProperty("#/definitions/ConceptGetRef"))
+					.property("programWorkflow", new ArrayProperty(new RefProperty("#/definitions/WorkflowCreateRef")))
+					.property("programWorkflowState", new ArrayProperty(new RefProperty("#/definitions/WorkflowStateCreateRef")));
+		}
+		return model;
+	}
+
+	@Override
+	public ConceptStateConversion newDelegate() {
+		return new ConceptStateConversion();
+	}
+
+	@Override
+	protected PageableResult doGetAll(RequestContext context) throws ResponseException {
+		return new NeedsPaging<>(Context.getProgramWorkflowService().getAllConceptStateConversions(), context);
+	}
+
+	@Override
+	public ConceptStateConversion getByUniqueId(String uniqueId) {
+		return Context.getProgramWorkflowService().getConceptStateConversionByUuid(uniqueId);
+	}
+
+	@Override
+	public ConceptStateConversion save(ConceptStateConversion delegate) {
+		if (!delegate.getProgramWorkflow().getConcept().getUuid().equals(delegate.getConcept().getUuid())) {
+			throw new IllegalRequestException("Program Workflow must belong to the same Concept as State Conversion");
+		}
+		if (!delegate.getProgramWorkflowState().getProgramWorkflow().getConcept().getUuid().equals(delegate.getConcept().getUuid())) {
+			throw new IllegalRequestException("Program Workflow State must belong to the same Concept as State Conversion");
+		}
+
+		return Context.getProgramWorkflowService().saveConceptStateConversion(delegate);
+	}
+
+	@Override
+	public void delete(ConceptStateConversion delegate, String reason, RequestContext context) throws ResponseException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void purge(ConceptStateConversion delegate, RequestContext context) throws ResponseException {
+		Context.getProgramWorkflowService().purgeConceptStateConversion(delegate);
+	}
+}

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
@@ -54,7 +54,7 @@ public class ConceptStateConversionController2_0Test extends MainResourceControl
 
 	@Override
 	public String getURI() {
-		return "stateconversion";
+		return "conceptstateconversion";
 	}
 
 	@Override

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
@@ -1,0 +1,124 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Concept;
+import org.openmrs.ConceptStateConversion;
+import org.openmrs.ProgramWorkflow;
+import org.openmrs.ProgramWorkflowState;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ConceptStateConversionController2_0Test extends MainResourceControllerTest {
+
+	private static String uuid;
+
+	@Before
+	public void setUp() {
+		Concept concept = Context.getConceptService().getConceptByUuid(RestTestConstants1_8.CONCEPT2_UUID);
+		ProgramWorkflow workflow = Context.getProgramWorkflowService().getWorkflowByUuid(RestTestConstants1_8.WORKFLOW_UUID);
+
+		ProgramWorkflowState state = new ProgramWorkflowState();
+		state.setConcept(concept);
+		state.setInitial(true);
+		state.setTerminal(false);
+
+		workflow.addState(state);
+		Context.getProgramWorkflowService().saveProgram(workflow.getProgram());
+
+		Context.flushSession();
+
+		ConceptStateConversion conceptStateConversion = new ConceptStateConversion();
+		conceptStateConversion.setConcept(concept);
+		conceptStateConversion.setProgramWorkflow(workflow);
+		conceptStateConversion.setProgramWorkflowState(state);
+
+		Context.getProgramWorkflowService().saveConceptStateConversion(conceptStateConversion);
+		uuid = conceptStateConversion.getUuid();
+	}
+
+	@Override
+	public String getURI() {
+		return "stateconversion";
+	}
+
+	@Override
+	public String getUuid() {
+		return uuid;
+	}
+
+	@Override
+	public long getAllCount() {
+		return 2;
+	}
+
+	@Test
+	public void shouldCreateStateConversion() throws Exception {
+		Concept concept = Context.getConceptService().getConceptByUuid("0955b484-b364-43dd-909b-1fa3655eaad2");
+		ProgramWorkflow workflow = Context.getProgramWorkflowService().getWorkflowByUuid(RestTestConstants1_8.WORKFLOW_UUID);
+
+		ProgramWorkflowState state = new ProgramWorkflowState();
+		state.setConcept(concept);
+		state.setInitial(true);
+		state.setTerminal(false);
+
+		workflow.addState(state);
+		Context.getProgramWorkflowService().saveProgram(workflow.getProgram());
+
+		Context.flushSession();
+
+		String json =
+				"{\"concept\": \"" + concept.getUuid() + "\",\"programWorkflow\": \"" + workflow.getUuid()
+						+ "\",\"programWorkflowState\": \"" + state.getUuid() + "\"}";
+
+		SimpleObject newStateConversion = deserialize(handle(newPostRequest(getURI(), json)));
+
+		assertNotNull(newStateConversion);
+		String uuid = newStateConversion.get("uuid");
+
+		ConceptStateConversion createdStateConversion = Context.getProgramWorkflowService().getConceptStateConversionByUuid(uuid);
+		assertEquals(workflow.getUuid(), createdStateConversion.getProgramWorkflow().getUuid());
+		assertEquals(state.getUuid(), createdStateConversion.getProgramWorkflowState().getUuid());
+		assertEquals(concept.getUuid(), createdStateConversion.getProgramWorkflow().getConcept().getUuid());
+	}
+
+	@Test
+	public void shouldPurgeStateConversion() throws Exception {
+		Concept concept = Context.getConceptService().getConceptByUuid("0955b484-b364-43dd-909b-1fa3655eaad2");
+		ProgramWorkflow workflow = Context.getProgramWorkflowService().getWorkflowByUuid(RestTestConstants1_8.WORKFLOW_UUID);
+
+		ProgramWorkflowState state = new ProgramWorkflowState();
+		state.setConcept(concept);
+		state.setInitial(true);
+		state.setTerminal(false);
+
+		workflow.addState(state);
+		Context.getProgramWorkflowService().saveProgram(workflow.getProgram());
+		Context.flushSession();
+
+		ConceptStateConversion conceptStateConversion = new ConceptStateConversion();
+		conceptStateConversion.setConcept(concept);
+		conceptStateConversion.setProgramWorkflow(workflow);
+		conceptStateConversion.setProgramWorkflowState(state);
+		Context.getProgramWorkflowService().saveConceptStateConversion(conceptStateConversion);
+
+		handle(newDeleteRequest(getURI() + "/" + conceptStateConversion.getUuid(), new Parameter("purge", "true")));
+
+		assertNull(Context.getProgramWorkflowService().getConceptStateConversionByUuid(conceptStateConversion.getUuid()));
+	}
+}

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
@@ -15,6 +15,7 @@ import org.openmrs.Concept;
 import org.openmrs.ConceptStateConversion;
 import org.openmrs.ProgramWorkflow;
 import org.openmrs.ProgramWorkflowState;
+import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
@@ -99,6 +100,8 @@ public class ConceptStateConversionController2_0Test extends MainResourceControl
 
 	@Test
 	public void shouldPurgeStateConversion() throws Exception {
+		ProgramWorkflowService service = Context.getProgramWorkflowService();
+
 		Concept concept = Context.getConceptService().getConceptByUuid("0955b484-b364-43dd-909b-1fa3655eaad2");
 		ProgramWorkflow workflow = Context.getProgramWorkflowService().getWorkflowByUuid(RestTestConstants1_8.WORKFLOW_UUID);
 
@@ -108,17 +111,19 @@ public class ConceptStateConversionController2_0Test extends MainResourceControl
 		state.setTerminal(false);
 
 		workflow.addState(state);
-		Context.getProgramWorkflowService().saveProgram(workflow.getProgram());
+		service.saveProgram(workflow.getProgram());
 		Context.flushSession();
 
 		ConceptStateConversion conceptStateConversion = new ConceptStateConversion();
 		conceptStateConversion.setConcept(concept);
 		conceptStateConversion.setProgramWorkflow(workflow);
 		conceptStateConversion.setProgramWorkflowState(state);
-		Context.getProgramWorkflowService().saveConceptStateConversion(conceptStateConversion);
+		service.saveConceptStateConversion(conceptStateConversion);
+
+		assertNotNull(service.getConceptStateConversionByUuid(conceptStateConversion.getUuid()));
 
 		handle(newDeleteRequest(getURI() + "/" + conceptStateConversion.getUuid(), new Parameter("purge", "true")));
 
-		assertNull(Context.getProgramWorkflowService().getConceptStateConversionByUuid(conceptStateConversion.getUuid()));
+		assertNull(service.getConceptStateConversionByUuid(conceptStateConversion.getUuid()));
 	}
 }

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
@@ -125,10 +125,12 @@ public class ConceptStateConversionController2_0Test extends MainResourceControl
 		conceptStateConversion.setProgramWorkflowState(state);
 		service.saveConceptStateConversion(conceptStateConversion);
 
+		int countBefore = service.getAllConceptStateConversions().size();
 		assertNotNull(service.getConceptStateConversionByUuid(conceptStateConversion.getUuid()));
 
 		handle(newDeleteRequest(getURI() + "/" + conceptStateConversion.getUuid(), new Parameter("purge", "true")));
 
 		assertNull(service.getConceptStateConversionByUuid(conceptStateConversion.getUuid()));
+		assertEquals(countBefore - 1, service.getAllConceptStateConversions().size());
 	}
 }

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptStateConversionController2_0Test.java
@@ -70,8 +70,12 @@ public class ConceptStateConversionController2_0Test extends MainResourceControl
 
 	@Test
 	public void shouldCreateStateConversion() throws Exception {
+		ProgramWorkflowService service = Context.getProgramWorkflowService();
+
+		int countBefore = service.getAllConceptStateConversions().size();
+
 		Concept concept = Context.getConceptService().getConceptByUuid("0955b484-b364-43dd-909b-1fa3655eaad2");
-		ProgramWorkflow workflow = Context.getProgramWorkflowService().getWorkflowByUuid(RestTestConstants1_8.WORKFLOW_UUID);
+		ProgramWorkflow workflow = service.getWorkflowByUuid(RestTestConstants1_8.WORKFLOW_UUID);
 
 		ProgramWorkflowState state = new ProgramWorkflowState();
 		state.setConcept(concept);
@@ -79,7 +83,7 @@ public class ConceptStateConversionController2_0Test extends MainResourceControl
 		state.setTerminal(false);
 
 		workflow.addState(state);
-		Context.getProgramWorkflowService().saveProgram(workflow.getProgram());
+		service.saveProgram(workflow.getProgram());
 
 		Context.flushSession();
 
@@ -92,7 +96,8 @@ public class ConceptStateConversionController2_0Test extends MainResourceControl
 		assertNotNull(newStateConversion);
 		String uuid = newStateConversion.get("uuid");
 
-		ConceptStateConversion createdStateConversion = Context.getProgramWorkflowService().getConceptStateConversionByUuid(uuid);
+		ConceptStateConversion createdStateConversion = service.getConceptStateConversionByUuid(uuid);
+		assertEquals(countBefore + 1, service.getAllConceptStateConversions().size());
 		assertEquals(workflow.getUuid(), createdStateConversion.getProgramWorkflow().getUuid());
 		assertEquals(state.getUuid(), createdStateConversion.getProgramWorkflowState().getUuid());
 		assertEquals(concept.getUuid(), createdStateConversion.getProgramWorkflow().getConcept().getUuid());

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0Test.java
@@ -44,7 +44,7 @@ public class ConceptStateConversionResource2_0Test
 
 	@Override
 	public String getDisplayProperty() {
-		return null;
+		return "ConceptStateConversion: Concept[Concept #16] results in State [State DIED initial=true terminal=false] for workflow [ProgramWorkflow(id=1)]";
 	}
 
 	@Override

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0Test.java
@@ -51,4 +51,28 @@ public class ConceptStateConversionResource2_0Test
 	public String getUuidProperty() {
 		return "e4f2fc12-0ca5-47d2-91bb-a129dca3149b";
 	}
+
+	@Override
+	public void validateRefRepresentation() throws Exception {
+		assertPropPresent("concept");
+		assertPropPresent("programWorkflow");
+		assertPropPresent("programWorkflowState");
+		super.validateRefRepresentation();
+	}
+
+	@Override
+	public void validateDefaultRepresentation() throws Exception {
+		assertPropPresent("concept");
+		assertPropPresent("programWorkflow");
+		assertPropPresent("programWorkflowState");
+		super.validateDefaultRepresentation();
+	}
+
+	@Override
+	public void validateFullRepresentation() throws Exception {
+		assertPropPresent("concept");
+		assertPropPresent("programWorkflow");
+		assertPropPresent("programWorkflowState");
+		super.validateFullRepresentation();
+	}
 }

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0Test.java
@@ -1,0 +1,54 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0;
+
+import org.openmrs.Concept;
+import org.openmrs.ConceptStateConversion;
+import org.openmrs.ProgramWorkflow;
+import org.openmrs.ProgramWorkflowState;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
+import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
+
+public class ConceptStateConversionResource2_0Test
+		extends BaseDelegatingResourceTest<ConceptStateConversionResource2_0, ConceptStateConversion> {
+
+	@Override
+	public ConceptStateConversion newObject() {
+		Concept concept = Context.getConceptService().getConceptByUuid(RestTestConstants1_8.CONCEPT2_UUID);
+		ProgramWorkflow workflow = Context.getProgramWorkflowService().getWorkflowByUuid(RestTestConstants1_8.WORKFLOW_UUID);
+
+		ProgramWorkflowState state = new ProgramWorkflowState();
+		state.setConcept(concept);
+		state.setInitial(true);
+		state.setTerminal(false);
+
+		workflow.addState(state);
+		Context.getProgramWorkflowService().saveProgram(workflow.getProgram());
+
+		ConceptStateConversion conceptStateConversion = new ConceptStateConversion();
+		conceptStateConversion.setConcept(concept);
+		conceptStateConversion.setProgramWorkflow(workflow);
+		conceptStateConversion.setProgramWorkflowState(state);
+		conceptStateConversion.setUuid("e4f2fc12-0ca5-47d2-91bb-a129dca3149b");
+
+		return conceptStateConversion;
+	}
+
+	@Override
+	public String getDisplayProperty() {
+		return null;
+	}
+
+	@Override
+	public String getUuidProperty() {
+		return "e4f2fc12-0ca5-47d2-91bb-a129dca3149b";
+	}
+}


### PR DESCRIPTION
## Description of what I changed
Added REST resource for Triggered State Conversions management

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-836

PR with documentation: https://github.com/openmrs/openmrs-contrib-rest-api-docs/pull/158

## Checklist: I completed these to help reviewers :)
- [X] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

