### PR TITLE
RESTWS-832: Update REST resource for Field Types management

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
@@ -23,6 +23,7 @@ import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 /**
@@ -118,5 +119,14 @@ public class FieldTypeResource1_8 extends MetadataDelegatingCrudResource<FieldTy
 	@Override
 	protected NeedsPaging<FieldType> doGetAll(RequestContext context) throws ResponseException {
 		return new NeedsPaging<FieldType>(Context.getFormService().getAllFieldTypes(), context);
+	}
+
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		description.addRequiredProperty("name");
+		description.addProperty("description");
+		description.addProperty("isSet");
+		return description;
 	}
 }

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
@@ -3,15 +3,17 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
- *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,9 +31,9 @@ import org.apache.commons.beanutils.PropertyUtils;
  * Tests functionality of {@link FieldTypeController}.
  */
 public class FieldTypeController1_8Test extends MainResourceControllerTest {
-	
+
 	private FormService service;
-	
+
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest#getURI()
 	 */
@@ -39,7 +41,7 @@ public class FieldTypeController1_8Test extends MainResourceControllerTest {
 	public String getURI() {
 		return "fieldtype";
 	}
-	
+
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest#getUuid()
 	 */
@@ -47,7 +49,7 @@ public class FieldTypeController1_8Test extends MainResourceControllerTest {
 	public String getUuid() {
 		return RestTestConstants1_8.FIELD_TYPE_UUID;
 	}
-	
+
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest#getAllCount()
 	 */
@@ -55,12 +57,12 @@ public class FieldTypeController1_8Test extends MainResourceControllerTest {
 	public long getAllCount() {
 		return 2;
 	}
-	
+
 	@Before
 	public void before() {
 		this.service = Context.getFormService();
 	}
-	
+
 	@Test
 	public void shouldUnRetireAFieldType() throws Exception {
 		FieldType fieldType = service.getFieldTypeByUuid(getUuid());
@@ -69,14 +71,64 @@ public class FieldTypeController1_8Test extends MainResourceControllerTest {
 		service.saveFieldType(fieldType);
 		fieldType = service.getFieldTypeByUuid(getUuid());
 		assertTrue(fieldType.isRetired());
-		
+
 		String json = "{\"deleted\": \"false\"}";
 		SimpleObject response = deserialize(handle(newPostRequest(getURI() + "/" + getUuid(), json)));
-		
+
 		fieldType = service.getFieldTypeByUuid(getUuid());
 		assertFalse(fieldType.isRetired());
 		assertEquals("false", PropertyUtils.getProperty(response, "retired").toString());
-		
+
 	}
-	
+
+	@Test
+	public void shouldCreateNewFieldType() throws Exception {
+		int countBefore = service.getAllFieldTypes().size();
+
+		String json = "{\"name\": \"test11\",\"description\": \"test\",\"isSet\": false}";
+		SimpleObject response = deserialize(handle(newPostRequest(getURI(), json)));
+
+		String uuid = response.get("uuid");
+		FieldType createdFieldType = service.getFieldTypeByUuid(uuid);
+
+		assertNotNull(createdFieldType);
+		assertEquals(countBefore + 1, service.getAllFieldTypes().size());
+		assertEquals("test11", createdFieldType.getName());
+		assertEquals("test", createdFieldType.getDescription());
+		assertEquals(false, createdFieldType.getIsSet());
+	}
+
+	@Test
+	public void shouldUpdateFieldType() throws Exception {
+		FieldType existingFieldType = new FieldType();
+		existingFieldType.setName("field type");
+		existingFieldType.setDescription("desc");
+		existingFieldType.setIsSet(false);
+		service.saveFieldType(existingFieldType);
+
+		String json = "{\"name\": \"field type\",\"description\": \"desc\",\"isSet\": true}";
+		handle(newPostRequest(getURI() + "/" + existingFieldType.getUuid(), json));
+		FieldType updatedFieldType = service.getFieldTypeByUuid(existingFieldType.getUuid());
+
+		assertNotNull(updatedFieldType);
+		assertEquals("field type", updatedFieldType.getName());
+		assertEquals("desc", updatedFieldType.getDescription());
+		assertEquals(true, updatedFieldType.getIsSet());
+	}
+
+	@Test
+	public void shouldPurgeFieldType() throws Exception {
+		FieldType existingFieldType = new FieldType();
+		existingFieldType.setName("field type");
+		existingFieldType.setDescription("desc");
+		existingFieldType.setIsSet(false);
+		service.saveFieldType(existingFieldType);
+
+		int countBefore = service.getAllFieldTypes().size();
+		handle(newDeleteRequest(getURI() + "/" + existingFieldType.getUuid(), new Parameter("purge", "true")));
+
+		FieldType deletedFieldType = service.getFieldTypeByUuid(existingFieldType.getUuid());
+		assertNull(deletedFieldType);
+		assertEquals(countBefore - 1, service.getAllFieldTypes().size());
+	}
 }


### PR DESCRIPTION
## Description of what I changed
I've added the ability to create FieldType with `isSet` field via REST API.

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-832

PR with updated documentation: https://github.com/openmrs/openmrs-contrib-rest-api-docs/pull/162

## Checklist: I completed these to help reviewers :)
- [X] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

