### PR TITLE
RESTWS-835: Add REST resource for Logged In Users

### DIFF
--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/LoggedInUsersController2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/LoggedInUsersController2_0.java
@@ -1,0 +1,52 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.BaseRestController;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.WebConstants;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/loggedinusers")
+public class LoggedInUsersController2_0 extends BaseRestController {
+
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public Object getLoggedInUsers(HttpSession httpSession) {
+		Context.requirePrivilege(PrivilegeConstants.GET_USERS);
+
+		ServletContext servletContext = httpSession.getServletContext();
+		Map<String, String> currentUsers = (Map<String, String>) servletContext.getAttribute(WebConstants.CURRENT_USERS);
+		if (currentUsers == null) {
+			currentUsers = new HashMap<>();
+		}
+
+		List<String> userNames = new ArrayList<>(currentUsers.values());
+		Collections.sort(userNames);
+		return userNames;
+	}
+}

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/LoggedInUsersController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/LoggedInUsersController2_0Test.java
@@ -1,0 +1,58 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.RestControllerTestUtils;
+import org.openmrs.web.WebConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class LoggedInUsersController2_0Test extends RestControllerTestUtils {
+
+	@Autowired
+	ApplicationContext context;
+
+	private String getURI() {
+		return "loggedinusers";
+	}
+
+	@Test
+	public void shouldGetLoggedInUsers() throws Exception {
+		// prepare mock session
+		MockHttpSession session = new MockHttpSession();
+		Map<String, String> users = new HashMap<>();
+		users.put("id", "username");
+		session.getServletContext().setAttribute(WebConstants.CURRENT_USERS, users);
+
+		// make GET request
+		MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/" + getNamespace() + "/" + getURI());
+		req.setSession(session);
+		MockHttpServletResponse response = handle(req);
+
+		// assert result
+		List<String> result = Arrays.asList(new ObjectMapper().readValue(response.getContentAsString(), String[].class));
+
+		assertEquals(1, result.size());
+		assertEquals("username", result.get(0));
+	}
+
+}


### PR DESCRIPTION
## Description of what I changed
Added LoggedInUsersController2_0 that allows querying logged-in users.

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-835
PR with documentation: https://github.com/openmrs/openmrs-contrib-rest-api-docs/pull/164

## Checklist: I completed these to help reviewers :)
- [X] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

