### PR TITLE
RESTWS-872: Removed unused imports from files

### DIFF
--- a/integration-tests/src/test/java/org/openmrs/module/webservices/rest/SessionIT.java
+++ b/integration-tests/src/test/java/org/openmrs/module/webservices/rest/SessionIT.java
@@ -11,8 +11,10 @@ package org.openmrs.module.webservices.rest;
 
 import org.junit.Test;
 
-import static io.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.*;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.empty;
 
 public class SessionIT extends ITBase {
 	

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_10/DrugController1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_10/DrugController1_10Test.java
@@ -23,7 +23,6 @@ import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openmrs.ConceptClass;
 import org.openmrs.Drug;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10Test.java
@@ -15,7 +15,7 @@ import org.openmrs.DrugOrder;
 import org.openmrs.Order;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class DrugOrderSubclassHandler1_10Test {
 	

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugResource1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugResource1_10Test.java
@@ -10,12 +10,10 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 
 import org.junit.Before;
-import org.junit.Test;
 import org.openmrs.Drug;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_10;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10.DrugResource1_10;
 
 public class DrugResource1_10Test extends BaseDelegatingResourceTest<DrugResource1_10, Drug> {
 	

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderEntryConfigResource1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderEntryConfigResource1_10Test.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 public class OrderEntryConfigResource1_10Test extends BaseModuleWebContextSensitiveTest {

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10Test.java
@@ -14,7 +14,6 @@ import org.openmrs.Order;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_10;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10.OrderResource1_10;
 
 public class OrderResource1_10Test extends BaseDelegatingResourceTest<OrderResource1_10, Order> {
 	

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderableResource1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderableResource1_10Test.java
@@ -9,19 +9,11 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.openmrs.Concept;
-import org.openmrs.ConceptClass;
 import org.openmrs.ConceptSearchResult;
-import org.openmrs.OrderType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_10;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public class OrderableResource1_10Test extends BaseDelegatingResourceTest<OrderableResource1_10, ConceptSearchResult> {
 	

--- a/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_12Test.java
+++ b/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_12Test.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
@@ -44,8 +44,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.hibernate.criterion.Projections.property;
-
 /**
  * Resource for Encounters, supporting standard CRUD operations
  */

--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
@@ -23,7 +23,6 @@ import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
-import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 /**

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptClassController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptClassController1_8Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
 import java.util.List;
-import java.util.Date;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptSourceController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ConceptSourceController1_8Test.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
-import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/EncounterTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/EncounterTypeController1_8Test.java
@@ -12,11 +12,9 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FieldTypeController1_8Test.java
@@ -18,8 +18,6 @@ import static org.junit.Assert.assertFalse;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
-
 import org.openmrs.FieldType;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.FormService;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FormController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/FormController1_8Test.java
@@ -15,8 +15,6 @@ import static org.junit.Assert.assertFalse;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
-
 import org.openmrs.Form;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.FormService;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PatientIdentifierTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PatientIdentifierTypeController1_8Test.java
@@ -12,11 +12,9 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PersonAttributeTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PersonAttributeTypeController1_8Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
 import java.util.List;
-import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RelationshipTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RelationshipTypeController1_8Test.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
-import java.util.Date;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;
 import org.junit.Before;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RoleController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/RoleController1_8Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8;
 
 import java.util.List;
-import java.util.Date;
 
 import javax.servlet.http.HttpServletResponse;
 

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.CohortResource1_8;
 import org.junit.Before;
 import org.openmrs.Cohort;
 import org.openmrs.api.context.Context;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.ConceptClass;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.ConceptClassResource1_8;
 
 public class ConceptClassResource1_8Test extends BaseDelegatingResourceTest<ConceptClassResource1_8, ConceptClass> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.ConceptDatatypeResource1_8;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.ConceptSource;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.ConceptSourceResource1_8;
 
 public class ConceptSourceResource1_8Test extends BaseDelegatingResourceTest<ConceptSourceResource1_8, ConceptSource> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.EncounterType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.EncounterTypeResource1_8;
 
 public class EncounterTypeResource1_8Test extends BaseDelegatingResourceTest<EncounterTypeResource1_8, EncounterType> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8Test.java
@@ -14,7 +14,6 @@ import org.openmrs.FieldAnswer;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.FieldAnswerResource1_8;
 
 public class FieldAnswerResource1_8Test extends BaseDelegatingResourceTest<FieldAnswerResource1_8, FieldAnswer> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.Field;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.FieldResource1_8;
 
 public class FieldResource1_8Test extends BaseDelegatingResourceTest<FieldResource1_8, Field> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.FieldType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.FieldTypeResource1_8;
 
 public class FieldTypeResource1_8Test extends BaseDelegatingResourceTest<FieldTypeResource1_8, FieldType> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.FormField;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.FormFieldResource1_8;
 
 public class FormFieldResource1_8Test extends BaseDelegatingResourceTest<FormFieldResource1_8, FormField> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.Form;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.FormResource1_8;
 
 public class FormResource1_8Test extends BaseDelegatingResourceTest<FormResource1_8, Form> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8Test.java
@@ -14,7 +14,6 @@ import org.openmrs.api.context.Context;
 import org.openmrs.hl7.HL7Source;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.HL7SourceResource1_8;
 
 public class HL7SourceResource1_8Test extends BaseDelegatingResourceTest<HL7SourceResource1_8, HL7Source> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import org.openmrs.module.Module;
-import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
 
 /**

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8Test.java
@@ -18,7 +18,6 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.OrderResource1_8;
 
 public class OrderResource1_8Test extends BaseDelegatingResourceTest<OrderResource1_8, Order> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8Test.java
@@ -14,7 +14,6 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.PatientIdentifierTypeResource1_8;
 
 public class PatientIdentifierTypeResource1_8Test extends BaseDelegatingResourceTest<PatientIdentifierTypeResource1_8, PatientIdentifierType> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.PersonAddressResource1_8;
 import org.openmrs.PersonAddress;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8Test.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 import org.openmrs.Privilege;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.PrivilegeResource1_8;
 
 public class PrivilegeResource1_8Test extends BaseDelegatingResourceTest<PrivilegeResource1_8, Privilege> {
 	

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8Test.java
@@ -13,7 +13,6 @@ import org.openmrs.Role;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.RoleResource1_8;
 
 public class RoleResource1_8Test extends BaseDelegatingResourceTest<RoleResource1_8, Role> {
 	

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitTypeResource1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitTypeResource1_9.java
@@ -12,13 +12,11 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.swagger.models.Model;
 import org.openmrs.VisitType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
-import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingCrudResource;

--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9.java
@@ -28,7 +28,11 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.PatientR
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
 
 /**
  * Allow searching for encounters based on an obs, matching the input patient and concept, within

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptMapController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptMapController1_9Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_9;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
@@ -21,13 +20,10 @@ import org.openmrs.ConceptMapType;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.test.Util;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_9;
 import org.openmrs.module.webservices.rest.web.api.RestHelperService;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * Tests CRUD operations for {@link ConceptMapType}s via web service calls

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptReferenceTermController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptReferenceTermController1_9Test.java
@@ -9,11 +9,9 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_9;
 
-import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.ConceptReferenceTerm;
@@ -29,16 +27,12 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptSearchController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptSearchController1_9Test.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertThat;
 import java.util.List;
 import java.util.Map;
 
-import org.azeckoski.reflectutils.refmap.FinalizableReference;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/EncounterController1_9Test.java
@@ -45,9 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 /**
  * Contains tests for the 19 ext {@link EncounterController} Overrides the failing test methods from

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/FieldController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/FieldController1_9Test.java
@@ -15,8 +15,6 @@ import static org.junit.Assert.assertFalse;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
-
 import org.openmrs.Field;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.FormService;

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/PersonController1_9Test.java
@@ -35,7 +35,11 @@ import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceContr
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests CRUD operations for {@link Person}s via web service calls

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProblemController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProblemController1_9Test.java
@@ -13,8 +13,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -31,7 +29,6 @@ import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
-import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest.Parameter;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMethod;
 

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProgramController1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ProgramController1_9Test.java
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Date;
 
 /**
  * Tests functionality of Program CRUD by MainResourceController

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9Test.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9;
 
 import org.openmrs.ConceptStopWord;
-import org.openmrs.Encounter;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
 

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderAttributeResource1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderAttributeResource1_9Test.java
@@ -17,7 +17,6 @@ import org.openmrs.ProviderAttribute;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_9;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.ProviderAttributeResource1_9;
 
 public class ProviderAttributeResource1_9Test extends BaseDelegatingResourceTest<ProviderAttributeResource1_9, ProviderAttribute> {
 	

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderAttributeTypeResource1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderAttributeTypeResource1_9Test.java
@@ -14,7 +14,6 @@ import org.openmrs.ProviderAttributeType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_9;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
-import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.ProviderAttributeTypeResource1_9;
 
 public class ProviderAttributeTypeResource1_9Test extends BaseDelegatingResourceTest<ProviderAttributeTypeResource1_9, ProviderAttributeType> {
 	

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/ConceptSearchHandler1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/ConceptSearchHandler1_9Test.java
@@ -13,7 +13,6 @@ import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openmrs.Concept;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_9/EncounterSearchHandler1_9Test.java
@@ -12,7 +12,6 @@ package org.openmrs.module.webservices.rest.web.v1_0.search.openmrs1_9;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Encounter;
-import org.openmrs.Order;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/VisitConfigurationController2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/VisitConfigurationController2_0.java
@@ -13,7 +13,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.BaseOpenmrsMetadata;
 import org.openmrs.BaseOpenmrsObject;
-import org.openmrs.GlobalProperty;
 import org.openmrs.VisitType;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.EncounterService;

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/converter/openmrs2_0/VisitConfigurationConverter2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/converter/openmrs2_0/VisitConfigurationConverter2_0.java
@@ -19,7 +19,6 @@ import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingConverter;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
-import org.openmrs.module.webservices.rest.web.response.GenericRestException;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_9.VisitTypeResource1_9;
 import org.openmrs.module.webservices.rest.web.v1_0.wrapper.VisitConfiguration;

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptResource2_0.java
@@ -16,7 +16,6 @@ import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
-import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11.ConceptResource1_11;

--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
@@ -31,7 +31,6 @@ import org.openmrs.module.webservices.rest.web.response.GenericRestException;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.util.DatabaseUpdater;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/EncounterController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/EncounterController2_0Test.java
@@ -25,8 +25,6 @@ import org.openmrs.module.webservices.rest.test.Util;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import static org.junit.Assert.assertEquals;
 

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/LocaleAndThemeConfigurationController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/LocaleAndThemeConfigurationController2_0Test.java
@@ -12,18 +12,14 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.openmrs.VisitType;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.RestTestConstants1_9;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.RestControllerTestUtils;
 import org.openmrs.scheduler.SchedulerException;
 import org.openmrs.util.OpenmrsConstants;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMethod;
-
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ProgramWorkflowStateController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ProgramWorkflowStateController2_0Test.java
@@ -10,8 +10,6 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
 
 import org.junit.Test;
-import org.openmrs.Concept;
-import org.openmrs.Program;
 import org.openmrs.ProgramWorkflow;
 import org.openmrs.ProgramWorkflowState;
 import org.openmrs.api.context.Context;

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ProviderController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ProviderController2_0Test.java
@@ -10,23 +10,18 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.codehaus.jackson.annotate.JsonTypeInfo;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.BaseOpenmrsObject;
-import org.openmrs.Provider;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.v1_0.RestTestConstants2_0;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ProviderController2_0Test extends MainResourceControllerTest {
 	

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/UserController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/UserController2_0Test.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.openmrs.User;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
-import org.openmrs.api.context.ContextAuthenticationException;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.test.Util;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -31,10 +30,6 @@ import org.openmrs.module.webservices.rest.web.v1_0.wrapper.openmrs1_8.UserAndPa
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.context.request.WebRequest;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class UserController2_0Test extends MainResourceControllerTest {
 	

--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/VisitConfigurationController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/VisitConfigurationController2_0Test.java
@@ -10,10 +10,8 @@
 package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_0;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.poi.hssf.record.formula.functions.Proper;
 import org.junit.Before;
 import org.junit.Test;
-import org.openmrs.GlobalProperty;
 import org.openmrs.VisitType;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.VisitService;

--- a/omod-2.1/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1Test.java
+++ b/omod-2.1/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1Test.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_1;
 
-import static org.junit.Assert.*;
-
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;

--- a/omod-2.2/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs2_2/OrderSearchHandler2_2.java
+++ b/omod-2.2/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs2_2/OrderSearchHandler2_2.java
@@ -30,7 +30,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Returns orders based on search by patient, care setting, concepts, order types, activated date

--- a/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_2/DiagnosisController2_2Test.java
+++ b/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_2/DiagnosisController2_2Test.java
@@ -11,7 +11,6 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs2_2;
 
 import static org.openmrs.ConditionVerificationStatus.CONFIRMED;
 
-import javax.validation.constraints.AssertTrue;
 import java.util.LinkedHashMap;
 
 import org.apache.commons.beanutils.PropertyUtils;

--- a/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/PatientProgramAttributeResource2_2Test.java
+++ b/omod-2.2/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/PatientProgramAttributeResource2_2Test.java
@@ -13,7 +13,6 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_2;
 import org.openmrs.PatientProgramAttribute;
 import org.openmrs.api.ProgramWorkflowService;
 import org.junit.Before;
-import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.v1_0.RestTestConstants2_2;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/api/RestServiceTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/api/RestServiceTest.java
@@ -14,7 +14,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RestConstants;
-import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.representation.NamedRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Removed **unused imports** in all the module and removed **wildcards**


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-872

