### PR TITLE
RESTWS-874: Fix End Point-Concept Attribute Types list test

### DIFF
--- a/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptAttributeTypeController2_0Test.java
+++ b/omod-2.0/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/ConceptAttributeTypeController2_0Test.java
@@ -17,6 +17,7 @@ import org.openmrs.ConceptAttributeType;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.test.Util;
 import org.openmrs.module.webservices.rest.web.v1_0.RestTestConstants2_0;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -74,6 +75,15 @@ public class ConceptAttributeTypeController2_0Test extends MainResourceControlle
         Assert.assertEquals(originalCount + 1 , getAllCount());
 
     }
+    
+	@Test
+	public void shouldListAllConceptAttributeTypes() throws Exception {
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+		SimpleObject result = deserialize(handle(req));
+		
+		Assert.assertNotNull(result);
+		Assert.assertEquals(getAllCount(), Util.getResultsSize(result));
+	}
 
     @Test
     public void shouldUpdateConceptAttributeType() throws Exception {


### PR DESCRIPTION

## Description of what I changed
I added an end point test for returning a list of concept attribute types

## Issue I worked on
[RESTWS-874](https://issues.openmrs.org/browse/RESTWS-874)

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ x] All new and existing **tests passed**.

- [x ] My pull request is **based on the latest changes** of the master branch.


