### PR TITLE
RESTWS-878 Fixed user Resource refreshes current authenticated user …

### DIFF
--- a/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/UserResource2_0.java
+++ b/omod-2.0/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/UserResource2_0.java
@@ -42,15 +42,27 @@ public class UserResource2_0 extends UserResource1_8 {
 	 */
 	@Override
 	public UserAndPassword1_8 save(UserAndPassword1_8 user) {
-		User openmrsUser = new User();
+		final User savedUser = createOrUpdateUser(user);
+		refreshAuthenticatedUserIfNeeded(savedUser);
+		return new UserAndPassword1_8(savedUser);
+	}
+
+	private User createOrUpdateUser(UserAndPassword1_8 user) {
+		final User openmrsUser;
+
 		if (user.getUser().getUserId() == null) {
 			openmrsUser = Context.getUserService().createUser(user.getUser(), user.getPassword());
 		} else {
 			openmrsUser = Context.getUserService().saveUser(user.getUser());
+		}
+
+		return openmrsUser;
+	}
+
+	private void refreshAuthenticatedUserIfNeeded(User savedUser) {
+		final User authenticatedUser = Context.getAuthenticatedUser();
+		if (authenticatedUser != null && authenticatedUser.getId().equals(savedUser.getId())) {
 			Context.refreshAuthenticatedUser();
 		}
-		
-		return new UserAndPassword1_8(openmrsUser);
-		
 	}
 }


### PR DESCRIPTION
## Description of what I changed
- authenticated user is only refreshed if it was updated

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-878

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.


