### PR TITLE
RESTWS-871 Follow naming convention for constants

### DIFF
--- a/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_11/EncounterRoleController1_11Test.java
+++ b/omod-1.11/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_11/EncounterRoleController1_11Test.java
@@ -40,15 +40,15 @@ public class EncounterRoleController1_11Test extends MainResourceControllerTest 
 	
 	@Test
 	public void shouldGetAnEncounterRoleByName() throws Exception {
-		final String ROLE_NAME = "Unknown";
+		final String roleName = "Unknown";
 		
 		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
-		req.setParameter("q", ROLE_NAME);
+		req.setParameter("q", roleName);
 		req.setParameter("v", "default");
 		SimpleObject result = deserialize(handle(req));
 		Object encounterRoleObject = Util.getResultsList(result).get(0);
 		
-		EncounterRole encounterRole = Context.getEncounterService().getEncounterRoleByName(ROLE_NAME);
+		EncounterRole encounterRole = Context.getEncounterService().getEncounterRoleByName(roleName);
 		Assert.assertEquals(encounterRole.getUuid(), PropertyUtils.getProperty(encounterRoleObject, "uuid"));
 		Assert.assertEquals(encounterRole.getName(), PropertyUtils.getProperty(encounterRoleObject, "name"));
 		Assert.assertEquals(encounterRole.getDescription(), PropertyUtils.getProperty(encounterRoleObject, "description"));


### PR DESCRIPTION

I changed the variable names so as to follow the convention adopted in rest of the codebase i.e., final variable should named like other variables and not as const(static final)


## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-871

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

