### PR TITLE
RESTWS-905 | Session should be invalidated only if its a valid session

### DIFF
--- a/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/SessionController1_9.java
+++ b/omod-1.9/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/SessionController1_9.java
@@ -121,7 +121,7 @@ public class SessionController1_9 extends BaseRestController {
 	public void delete(HttpServletRequest request) {
 		Context.logout();
 		HttpSession session = request.getSession(false);
-		if (session != null) {
+		if (session != null && request.isRequestedSessionIdValid()) {
 			session.invalidate();
 		}
 	}


### PR DESCRIPTION
In case a DELETE call is not accompanied with a JSESSIONID (e.g. in case of COOKIE expiry), the current code was invalidating a newly created session, resulting in subsequent calls failing with the JSESSIONID sent back thats already invalidated. (the user can not proceed without clearing the app cache or waiting for the cookie to expire)

