### PR TITLE
RESTWS-908 Diagnosis resource should return formNamespace and formPath on core 2.5+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,7 @@
 				<module>omod-2.2</module>
 				<module>omod-2.3</module>
 				<module>omod-2.4</module>
+				<module>omod-2.5</module>
 				<module>omod</module>
 				<module>integration-tests</module>
 			</modules>
@@ -501,6 +502,7 @@
 				<module>omod-2.2</module>
 				<module>omod-2.3</module>
 				<module>omod-2.4</module>
+				<module>omod-2.5</module>
 				<module>omod</module>
 				<module>integration-tests</module>
 			</modules>
@@ -569,4 +571,7 @@
 		</pluginRepository>
 	</pluginRepositories>
 
+	<modules>
+		<module>webservices.rest-omod-2.5</module>
+	</modules>
 </project>

--- a/webservices.rest-omod-2.5/pom.xml
+++ b/webservices.rest-omod-2.5/pom.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+	  	<artifactId>webservices.rest</artifactId>
+    	<groupId>org.openmrs.module</groupId>
+    	<version>2.40.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>webservices.rest-omod-2.5</artifactId>
+  <name>Rest Web Services 2.5 OMOD</name>
+  
+   	<properties>
+        <openmrs.version.2.5.0>2.5.0</openmrs.version.2.5.0>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-common</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.8</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.8</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.9</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.9</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.10</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.10</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.11</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-1.11</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.0</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.2</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.2</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.3</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.3</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.4</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.4</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-omod-2.0</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <version>${openmrs.version.2.5.0}</version><!--$NO-MVN-MAN-VER$-->
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${openmrs.version.2.5.0}</version><!--$NO-MVN-MAN-VER$-->
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.web</groupId>
+            <artifactId>openmrs-web</artifactId>
+            <version>${openmrs.version.2.5.0}</version> <!-- $NO-MVN-MAN-VER$ -->
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.web</groupId>
+            <artifactId>openmrs-web</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${openmrs.version.2.5.0}</version> <!-- $NO-MVN-MAN-VER$-->
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.test</groupId>
+            <artifactId>openmrs-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+            <version>${openmrs.version.2.5.0}</version> <!-- $NO-MVN-MAN-VER$ -->
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javaxVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+		      <groupId>org.apache.tomcat</groupId>
+		      <artifactId>jasper</artifactId>
+		      <version>6.0.18</version>
+		      <scope>provided</scope>
+	     </dependency>
+	     
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license-header.txt</header>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+  
+</project>

--- a/webservices.rest-omod-2.5/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5.java
+++ b/webservices.rest-omod-2.5/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5.java
@@ -1,0 +1,75 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_5;
+
+import org.openmrs.Diagnosis;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_2.DiagnosisResource2_2;
+
+/**
+ * {@link Resource} for Diagnosis, supporting standard CRUD operations
+ */
+@Resource(name = RestConstants.VERSION_1
+        + "/patientdiagnoses", supportedClass = Diagnosis.class, supportedOpenmrsVersions = { "2.5.* - 9.*" })
+public class DiagnosisResource2_5 extends DiagnosisResource2_2 {
+	
+	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)
+	 */
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation representation) {
+		if (representation instanceof DefaultRepresentation) {
+			DelegatingResourceDescription description = super.getRepresentationDescription(representation);
+			description.addProperty("formNamespace");
+			description.addProperty("formPath");
+			return description;
+		} else if (representation instanceof FullRepresentation) {
+			DelegatingResourceDescription description = super.getRepresentationDescription(representation);
+			description.addProperty("formNamespace");
+			description.addProperty("formPath");
+			return description;
+		}
+		
+		return null;
+	}
+	
+	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getCreatableProperties()
+	 */
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription description = super.getCreatableProperties();
+		
+		description.addRequiredProperty("formNamespace");
+		description.addRequiredProperty("formPath");
+		
+		return description;
+		
+	}
+	
+	/**
+	 * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getUpdatableProperties()
+	 */
+	@Override
+	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription description = super.getUpdatableProperties();
+		
+		description.addRequiredProperty("formNamespace");
+		description.addRequiredProperty("formPath");
+		
+		return description;
+	}
+}

--- a/webservices.rest-omod-2.5/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5Test.java
+++ b/webservices.rest-omod-2.5/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5Test.java
@@ -1,0 +1,33 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_5;
+
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_2.DiagnosisResource2_2;
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_2.DiagnosisResource2_2Test;
+
+/**
+ * Tests functionality of {@link DiagnosisResource2_2}.
+ */
+public class DiagnosisResource2_5Test extends DiagnosisResource2_2Test {
+	
+	@Override
+	public void validateDefaultRepresentation() throws Exception {
+		super.validateDefaultRepresentation();
+		assertPropPresent("formNamespace");
+		assertPropPresent("formPath");
+	}
+	
+	@Override
+	public void validateFullRepresentation() throws Exception {
+		super.validateDefaultRepresentation();
+		assertPropPresent("formNamespace");
+		assertPropPresent("formPath");
+	}
+}


### PR DESCRIPTION
RESTWS-908 Diagnosis resource should return formNamespace and formPath on core 2.5+
RESTWS-908 
I created a new submodule 2.5 and created a diagnosisResource class that extends the DiagnosisResource2_2 class in the 2.2 module. I added the formNamespace properties such that they can be returned.



## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

