### PR TITLE
RESTWS-904 Support custom representation for Map objects

### DIFF
--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PatientIdentifierTypeController1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/PatientIdentifierTypeController1_8Test.java
@@ -168,4 +168,21 @@ public class PatientIdentifierTypeController1_8Test extends MainResourceControll
 		
 		assertNotNull(PropertyUtils.getProperty(result, "auditInfo"));
 	}
+	
+	@Test
+	public void shouldReturnCustomRepresentationForAuditInfo() throws Exception {
+		SimpleObject result = deserialize(
+				handle(newGetRequest(getURI() + "/" + getUuid(),
+						new Parameter("v", "custom:(auditInfo:(creator:(uuid),dateCreated))"))));
+		
+		assertNotNull(PropertyUtils.getProperty(result, "auditInfo"));
+		assertNotNull(PropertyUtils.getProperty(result, "auditInfo.creator"));
+		assertNotNull(PropertyUtils.getProperty(result, "auditInfo.creator.uuid"));
+		assertNotNull(PropertyUtils.getProperty(result, "auditInfo.dateCreated"));
+		
+		assertNull(PropertyUtils.getProperty(result, "name"));
+		assertNull(PropertyUtils.getProperty(result, "links"));
+		assertNull(PropertyUtils.getProperty(result, "auditInfo.creator.display"));
+		assertNull(PropertyUtils.getProperty(result, "auditInfo.creator.links"));
+	}
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
@@ -389,6 +389,9 @@ public class ConversionUtil {
 			}
 			return ret;
 		} else if (o instanceof Map) {
+			if (rep instanceof CustomRepresentation) {
+				return convertToCustomRepresentation(o, (CustomRepresentation) rep);
+			}
 			SimpleObject ret = new SimpleObject();
 			for (Map.Entry<?, ?> entry : ((Map<?, ?>) o).entrySet()) {
 				ret.put(entry.getKey().toString(),
@@ -412,6 +415,24 @@ public class ConversionUtil {
 				throw new ConversionException("converting " + o.getClass() + " to " + rep, ex);
 			}
 		}
+	}
+	
+	/**
+	 * Converts an object to its custom representation
+	 * This could be used to convert any domain objects that does not have any specific converter associated with them
+	 * such as SimpleObject's, Map's, etc
+	 */
+	private static SimpleObject convertToCustomRepresentation(Object o, CustomRepresentation rep) {
+		DelegatingResourceDescription drd = ConversionUtil.getCustomRepresentationDescription(rep);
+		
+		SimpleObject result = new SimpleObject();
+		for (String propertyName : drd.getProperties().keySet()) {
+			DelegatingResourceDescription.Property property = drd.getProperties().get(propertyName);
+			Object propertyValue = ConversionUtil.getPropertyWithRepresentation(o, propertyName, property.getRep());
+			result.add(propertyName, propertyValue);
+		}
+		
+		return result;
 	}
 	
 	/**

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtilTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtilTest.java
@@ -10,7 +10,7 @@
 package org.openmrs.module.webservices.rest.web;
 
 import static org.hamcrest.core.Is.is;
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.lang.reflect.Method;
@@ -25,8 +25,11 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.beanutils.PropertyUtils;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.api.ConceptNameType;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
 
@@ -143,6 +146,26 @@ public class ConversionUtilTest extends BaseModuleWebContextSensitiveTest {
 		String input = "java.lang.String";
 		Class converted = (Class) ConversionUtil.convert(input, Class.class);
 		Assert.assertTrue(converted.isAssignableFrom(String.class));
+	}
+	
+	@Test
+	public void convert_shouldConvertSimpleObjectToCustomRepresentation() throws Exception {
+		
+		SimpleObject child = new SimpleObject();
+		child.put("child_key_1", "child_val_1");
+		child.put("child_key_2", "child_val_2");
+		SimpleObject parent = new SimpleObject();
+		parent.put("parent_key_1", child);
+		parent.put("parent_key_2", "parent_val_2");
+		
+		Object o = ConversionUtil.convertToRepresentation(parent, new CustomRepresentation("parent_key_1:(child_key_1)"));
+		
+		SimpleObject expectedChild = new SimpleObject();
+		expectedChild.put("child_key_1", "child_val_1");
+		SimpleObject expectedParent = new SimpleObject();
+		expectedParent.put("parent_key_1", expectedChild);
+		
+		assertEquals(expectedParent, o);
 	}
 	
 	public void convert_shouldConvertIntToDouble() throws Exception {


### PR DESCRIPTION
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

This issue is that, `ConversionUtil#convertToRepresentation(object, representation, converter)`, does not use the `representation` param, when the `object` param is of type `Map`. So it'll always return an object with all the elements in the map, even if the caller wants to convert it to a custom representation.

https://github.com/openmrs/openmrs-module-webservices.rest/blob/6d01f5fdef274903c242645456c7d5a7fab0a9e7/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java#L379-L397

As shown below every value in the map is converted to it's `REF` representation.
https://github.com/openmrs/openmrs-module-webservices.rest/blob/6d01f5fdef274903c242645456c7d5a7fab0a9e7/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java#L393-L395

`auditInfo` objects are of type `Map`, hence facing the same issue as reported in [RESTWS-904](https://openmrs.atlassian.net/browse/RESTWS-904)

This PR refactors `ConversionUtil`, so objects of type `Map` can be converted to custom representations.

## Issue I worked on
see https://openmrs.atlassian.net/browse/RESTWS-904

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`



[RESTWS-904]: https://openmrs.atlassian.net/browse/RESTWS-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ