### PR TITLE
RESTWS-940: PersonAttributeResource should not try to hydrate the attribute itself

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
@@ -65,7 +65,7 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 			description.addProperty("display");
 			description.addProperty("uuid");
 			description.addProperty("value");
-			description.addProperty("attributeType", Representation.REF);
+			description.addProperty("attributeType", Representation.FULL);
 			description.addProperty("voided");
 			description.addProperty("auditInfo");
 			description.addProperty("hydratedObject");
@@ -284,17 +284,18 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 	 * Gets the display string for a person attribute.
 	 * 
 	 * @param pa the person attribute.
-	 * @return attribute type + value (for concise display purposes)
+	 * @return value (for concise display purposes)
 	 */
 	@PropertyGetter("display")
 	public String getDisplayString(PersonAttribute pa) {
-		if (pa.getAttributeType() == null)
-			return "";
-		if (Concept.class.getName().equals(pa.getAttributeType().getFormat()) && pa.getValue() != null) {
-			Concept concept = Context.getConceptService().getConcept(pa.getValue());
-			return concept == null ? null : concept.getDisplayString();
+		// a PersonAttribute without a type cannot really be converted
+		if (pa.getAttributeType() == null) {
+			return pa.getValue() != null ? pa.getValue() : "";
 		}
-		return pa.getAttributeType().getName() + " = " + pa.getValue();
+
+		// PersonAttribute#toString() calls PersonAttribute#hydrateObject() and Attributable#getDisplayString()
+		String value = pa.toString();
+		return value == null ? "" : value;
 	}
 	
 	/**

--- a/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CreateUpdatePatientResource1_9Test.java
+++ b/omod-1.9/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CreateUpdatePatientResource1_9Test.java
@@ -70,7 +70,7 @@ public class CreateUpdatePatientResource1_9Test extends BaseModuleWebContextSens
 		Map preferredAddress = (Map) person.get("preferredAddress");
 		Assert.assertEquals("address 1", preferredAddress.get("display"));
 		List<Map> attributes = (List<Map>) person.get("attributes");
-		Assert.assertEquals("Race = Muslim", attributes.get(0).get("display"));
+		Assert.assertEquals("Muslim", attributes.get(0).get("display"));
 	}
 	
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

Previously, `PersonAttributeResource1_8#getDisplayString()` had two different formats:

1. For attributes without an attribute type, an empty string
2. For concepts, the concept display string
3. For anything else, `AttributeType = <AttributeValue>`; e.g., `Current Location = 4`

This PR ensures that `getDisplayString()` continues to work like 1 and 2 above, but replaces 3 with something more similar to 2, that is, the display string for the value. This means that in the `Current Location` example above, `getDisplayString()` would return a string like "Ward 3".

The AttributeType name can be fetched via a custom display, and the raw value can be read via the `value` property. Nevertheless, this is technically a breaking change.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-940

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

