### PR TITLE
(chore) O3-3551: Use latest Actions in GH Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
       - name: Cache local Maven repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
+        distribution: 'zulu'
         with:
           java-version: ${{ matrix.java-version }}
       - name: Cache local Maven repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,9 +24,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
-        distribution: 'zulu'
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: 'zulu'
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
       - name: Cache local Maven repository
-        uses: actions/cache@v
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,13 +21,13 @@ jobs:
       JAVA_VERSION: ${{ matrix.java-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v
         with:
           java-version: ${{ matrix.java-version }}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
https://openmrs.atlassian.net/browse/O3-3551

This pull request updates the GitHub Actions workflow to utilize the latest versions of several key actions, improving performance, security, and feature set. The specific updates include:

1.actions/checkout: Updated from `v2` to `v4`.
2. actions/cache: Updated from `v2` to `v3`.
3.actions/setup-java: Updated from `v1` to `v3`.

Benefits:
- Enhanced Performance: The latest versions come with performance improvements, which can speed up the workflow execution.
- Improved Security: Newer versions include the latest security patches, reducing the risk of vulnerabilities.
- Advanced Features: The updated actions provide additional features and improvements, such as better caching mechanisms and more robust setup options for Java.

Detailed Changes:
1. actions/checkout@v4
   - Improved performance and reliability in fetching the repository.
   - Enhanced support for submodules and large repositories.

2. actions/cache@v3
   - Optimized caching strategies to reduce build times.
   - Better handling of cache keys and restore-keys, ensuring more efficient cache usage.

3. actions/setup-java@v3
   - Better support for multiple Java versions and configurations.
   - Improved caching of Java dependencies, reducing setup times.