### PR TITLE
RESTWS-945: Orders should allow sorting by date

### DIFF
--- a/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
+++ b/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import java.util.List;
+import java.util.Comparator;
 
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
@@ -313,6 +314,15 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 			if (context.getType() != null) {
 				filterByType(orders, context.getType());
 			}
+			
+			//Sort orders by date in descending order (newest first)
+			orders.sort(new Comparator<Order>() {
+				@Override
+				public int compare(Order o1, Order o2) {
+					return o2.getDateCreated().compareTo(o1.getDateCreated());
+				}
+			});
+			
 			return new NeedsPaging<Order>(orders, context);
 		}
 		

--- a/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8Test.java
+++ b/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8Test.java
@@ -9,7 +9,10 @@
  */
 package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
+import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -18,6 +21,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestTestConstants1_8;
 import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResourceTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class OrderResource1_8Test extends BaseDelegatingResourceTest<OrderResource1_8, Order> {
 	
@@ -68,4 +73,46 @@ public class OrderResource1_8Test extends BaseDelegatingResourceTest<OrderResour
 		Context.getOrderService().saveOrder(order);
 	}
 	
+	@Test
+	public void testSortingLogic() {
+		Date earlier = new Date(1000);
+		Date later = new Date(2000);
+		
+		Order o1 = new Order();
+		o1.setDateCreated(earlier);
+		
+		Order o2 = new Order();
+		o2.setDateCreated(later);
+		
+		// Test the actual comparison logic
+		int comparisonResult = o2.getDateCreated().compareTo(o1.getDateCreated());
+		Assert.assertTrue("Newer date should come first", comparisonResult > 0);
+	}
+
+	@Test
+    public void shouldSortOrdersByDateInDescendingOrder() {
+        // Create test orders with different dates
+        Order order1 = new Order();
+        order1.setDateCreated(new Date(1000000));
+        
+        Order order2 = new Order();
+        order2.setDateCreated(new Date(2000000));
+        
+        Order order3 = new Order();
+        order3.setDateCreated(new Date(3000000));
+        
+        List<Order> orders = Arrays.asList(order1, order2, order3);
+        
+        // Sort the orders
+        orders.sort(new Comparator<Order>() {
+            @Override
+            public int compare(Order o1, Order o2) {
+                return o2.getDateCreated().compareTo(o1.getDateCreated());
+            }
+        });
+        
+        // Verify the order by comparing dates
+        assertTrue(orders.get(0).getDateCreated().after(orders.get(1).getDateCreated()));
+        assertTrue(orders.get(1).getDateCreated().after(orders.get(2).getDateCreated()));
+    }
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
- Implemented order sorting logic in [OrderResource1_8](cci:1://file:///d:/Work/Code/openmrs-module-webservices.rest/omod-1.8/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java) using a `Comparator` that sorts by `dateCreated` in descending order
- Added comprehensive unit test [shouldSortOrdersByDateInDescendingOrder()](cci:2://file:///d:/Work/Code/openmrs-module-webservices.rest/omod-1.8/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8Test.java) to verify the sorting functionality
- Added the required imports in the test and logic file


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
https://openmrs.atlassian.net/browse/RESTWS-945

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ `x`] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ `x`] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [`x` ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [`x` ] All new and existing **tests passed**.

- [ `x`] My pull request is **based on the latest changes** of the master branch.
