### PR TITLE
RESTWS-943 : ObservationSearchHandler should be chosen to handle obs search request when `totalCount` is passed in

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/RestConstants.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/RestConstants.java
@@ -135,6 +135,11 @@ public class RestConstants {
 	public static final String REQUEST_PROPERTY_FOR_SEARCH_ID = "s";
 	
 	/**
+	 * An optional request parameter for getting the total count of results
+	 */
+	public static final String REQUEST_PROPERTY_FOR_TOTAL_COUNT = "totalCount";
+	
+	/**
 	 * Used in object representations to indicate which specific type an instance belongs to for a
 	 * resource that represents a full class hierarchy
 	 */
@@ -189,7 +194,7 @@ public class RestConstants {
 		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_JSESSIONID);
 		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_SEARCH_ID);
 		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_TYPE);
-		SPECIAL_REQUEST_PARAMETERS.add("totalCount");
+		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_TOTAL_COUNT);
 	}
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/RestConstants.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/RestConstants.java
@@ -179,7 +179,7 @@ public class RestConstants {
 	 * A set of special request parameter names
 	 */
 	public static final Set<String> SPECIAL_REQUEST_PARAMETERS;
-	
+
 	static {
 		SPECIAL_REQUEST_PARAMETERS = new HashSet<String>();
 		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_INCLUDE_ALL);
@@ -189,6 +189,7 @@ public class RestConstants {
 		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_JSESSIONID);
 		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_SEARCH_ID);
 		SPECIAL_REQUEST_PARAMETERS.add(REQUEST_PROPERTY_FOR_TYPE);
+		SPECIAL_REQUEST_PARAMETERS.add("totalCount");
 	}
 	
 	/**


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
This PR fixes an issue where adding the `totalCount=true` parameter to observation search requests causes the request to bypass the ObservationSearchHandler1_8 and fall back to ObsResource1_8.doSearch(), resulting in inconsistent filtering behavior.

The root cause was that `totalCount` was not included in the SPECIAL_REQUEST_PARAMETERS set in RestConstants.java. When present in a request, it was treated as a regular parameter affecting handler selection. Since ObservationSearchHandler1_8 doesn't declare `totalCount` as a parameter, requests with this parameter were not being routed to it.

By adding `totalCount` to SPECIAL_REQUEST_PARAMETERS, we ensure it doesn't affect handler selection while still being available for pagination functionality. This allows observation searches to be properly filtered by both patient and concept parameters, regardless of whether the `totalCount` parameter is present.

The fix was verified by testing API requests with and without the `totalCount` parameter, confirming that both return the same filtered results, with the only difference being the inclusion of the total count in the response when requested.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
https://openmrs.atlassian.net/browse/RESTWS-943

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ `x`] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ `x`] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ `x`] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ `x`] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

