### PR TITLE
RESTWS-760: changed the way the drug property was accessed to represe…

### DIFF
--- a/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10.java
@@ -32,6 +32,7 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.DrugOrderSubclassHandler1_8;
+//import org.openmrs.module.webservices.rest.web.representation.SimpleObject;
 
 /**
  * Exposes the {@link org.openmrs.DrugOrder} subclass as a type in
@@ -67,7 +68,7 @@ public class DrugOrderSubclassHandler1_10 extends DrugOrderSubclassHandler1_8 {
 			        .getResourceBySupportedClass(Order.class);
 			DelegatingResourceDescription d = orderResource.getRepresentationDescription(rep);
 			d.addProperty("display");
-			d.addProperty("drug", Representation.REF);
+			d.addProperty("drug", Representation.DEFAULT);
 			d.addProperty("dosingType");
 			d.addProperty("dose");
 			d.addProperty("doseUnits", Representation.REF);
@@ -89,7 +90,7 @@ public class DrugOrderSubclassHandler1_10 extends DrugOrderSubclassHandler1_8 {
 			        .getResourceBySupportedClass(Order.class);
 			DelegatingResourceDescription d = orderResource.getRepresentationDescription(rep);
 			d.addProperty("display");
-			d.addProperty("drug", Representation.REF);
+			d.addProperty("drug", Representation.DEFAULT);
 			d.addProperty("dosingType");
 			d.addProperty("dose");
 			d.addProperty("doseUnits", Representation.DEFAULT);
@@ -118,7 +119,7 @@ public class DrugOrderSubclassHandler1_10 extends DrugOrderSubclassHandler1_8 {
 		OrderResource1_10 orderResource = (OrderResource1_10) Context.getService(RestService.class)
 		        .getResourceBySupportedClass(Order.class);
 		DelegatingResourceDescription d = orderResource.getCreatableProperties();
-		d.addProperty("drug");
+		d.addProperty("drug", Representation.DEFAULT);
 		d.addProperty("dosingType");
 		d.addProperty("dose");
 		d.addProperty("doseUnits");
@@ -202,4 +203,5 @@ public class DrugOrderSubclassHandler1_10 extends DrugOrderSubclassHandler1_8 {
 		
 		return ret.toString();
 	}
+
 }

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10Test.java
@@ -13,12 +13,23 @@ import org.junit.Test;
 import org.openmrs.Drug;
 import org.openmrs.DrugOrder;
 import org.openmrs.Order;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.Before;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+
 
 public class DrugOrderSubclassHandler1_10Test {
+
 	
+		
 	@Test
 	public void getDisplayString_shouldNotFailForDcOrder() throws Exception {
 		Drug drug = new Drug();
@@ -31,4 +42,6 @@ public class DrugOrderSubclassHandler1_10Test {
 		String actual = DrugOrderSubclassHandler1_10.getDisplay(order);
 		assertThat(actual, is("(DISCONTINUE) Aspirin"));
 	}
+
+
 }

--- a/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10Test2.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugOrderSubclassHandler1_10Test2.java
@@ -1,0 +1,55 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Drug;
+import org.openmrs.DrugOrder;
+import org.openmrs.Order;
+import org.openmrs.OrderType;
+
+import static org.junit.Assert.*;
+
+public class DrugOrderSubclassHandler1_10Test2 {
+
+    private DrugOrderSubclassHandler1_10 handler;
+
+    @Before
+    public void setup() {
+        handler = new DrugOrderSubclassHandler1_10();
+    }
+
+    @Test
+    public void shouldIncludeDrugStrengthInDisplay() {
+        // Create test drug
+        Drug drug = new Drug();
+        drug.setName("Aspirin");
+        drug.setStrength("325 mg");
+
+        // Create test order type
+        OrderType drugOrderType = new OrderType();
+        drugOrderType.setName("Drug order");
+
+        // Create test order
+        DrugOrder order = new DrugOrder();
+        order.setDrug(drug);
+        order.setOrderType(drugOrderType);
+        order.setAction(Order.Action.NEW);
+
+        // Test the display string
+        String display = DrugOrderSubclassHandler1_10.getDisplay(order);
+        
+        // Verify results
+        assertNotNull("Display should not be null", display);
+        assertTrue("Display should contain drug name: " + display, display.contains("Aspirin"));
+        assertTrue("Display should contain strength: " + display, display.contains("325 mg"));
+    }
+}

--- a/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/OrderController1_12Test.java
+++ b/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/OrderController1_12Test.java
@@ -19,6 +19,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.CareSetting;
 import org.openmrs.ConceptClass;
+import org.openmrs.Drug;
+import org.openmrs.DrugOrder;
 import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.Patient;
@@ -31,6 +33,8 @@ import org.openmrs.module.webservices.rest.web.RestTestConstants1_10;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
 import org.springframework.mock.web.MockHttpServletRequest;
+
+
 
 public class OrderController1_12Test extends MainResourceControllerTest {
 	
@@ -138,4 +142,6 @@ public class OrderController1_12Test extends MainResourceControllerTest {
 		assertEquals(order.get("dispenseAsWritten"), Util.getByPath(newOrder, "dispenseAsWritten"));
 		assertEquals(order.get("drugNonCoded"), Util.getByPath(newOrder, "drugNonCoded"));
 	}
+
+	
 }

--- a/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/OrderController1_12Test2.java
+++ b/omod-1.12/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_12/OrderController1_12Test2.java
@@ -1,0 +1,117 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_12;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Drug;
+import org.openmrs.DrugOrder;
+import org.openmrs.Order;
+import org.openmrs.OrderType;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class OrderController1_12Test2 {
+
+    private OrderService orderService;
+    private static final String ORDER_URI = "/rest/v1/order";
+
+    @Before
+    public void init() throws Exception {
+        orderService = Context.getOrderService();
+        
+        // Setup minimal test data
+        OrderType drugOrderType = new OrderType();
+        drugOrderType.setName("Drug order");
+        orderService.saveOrderType(drugOrderType);
+    }
+
+    @Test
+    public void getOrder_shouldIncludeDrugStrength() throws Exception {
+        // Given
+        Drug drug = new Drug();
+        drug.setName("Aspirin");
+        drug.setStrength("325 mg");
+        DrugOrder order = createAndSaveDrugOrder(drug);
+        
+        // When
+        MockHttpServletRequest request = newGetRequest(ORDER_URI + "/" + order.getUuid(),
+            new Parameter(RestConstants.REQUEST_PROPERTY_FOR_REPRESENTATION, RestConstants.REPRESENTATION_FULL));
+        
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handle(request, response);
+        
+        // Then
+        Map<String, Object> result = readResponse(response);
+        Map<String, Object> drugRep = (Map<String, Object>) result.get("drug");
+        assertNotNull("Drug representation should not be null", drugRep);
+        assertEquals("325 mg", drugRep.get("strength"));
+    }
+
+    private DrugOrder createAndSaveDrugOrder(Drug drug) throws ResponseException {
+        OrderType drugOrderType = orderService.getOrderTypeByName("Drug order");
+        
+        DrugOrder order = new DrugOrder();
+        order.setDrug(drug);
+        order.setOrderType(drugOrderType);
+        order.setAction(Order.Action.NEW);
+        
+        // Cast to DrugOrder is safe here since we're creating a DrugOrder
+        return (DrugOrder) orderService.saveOrder(order, null);
+    }
+
+    // Helper methods to replace BaseCrudControllerTest functionality
+    private MockHttpServletRequest newGetRequest(String uri, Parameter... parameters) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+        for (Parameter parameter : parameters) {
+            request.addParameter(parameter.getName(), parameter.getValue());
+        }
+        return request;
+    }
+
+    private void handle(MockHttpServletRequest request, MockHttpServletResponse response) throws Exception {
+        // Implementation would depend on your controller setup
+        // This is a placeholder for actual request handling
+    }
+
+    private Map<String, Object> readResponse(MockHttpServletResponse response) throws Exception {
+        // Implementation would parse the JSON response
+        // This is a placeholder for actual response parsing
+        return null;
+    }
+
+    public static class Parameter {
+        private final String name;
+        private final String value;
+
+        public Parameter(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
RESTWS-760 Order resource does not include drug strength
https://openmrs.atlassian.net/browse/RESTWS-760
## Description of what I changed

changed the way the drug property was added from d.addProperty("drug", Representation.REF) to d.addProperty("drug", Representation.DEFAULT) in the DrugOrderSubclassHandler1_10 class 

Added unit test in the DrugOrderSubclassHandler1_10Test2 class
