### PR TITLE
RESTWS-971: Fix property double-set in convertMap causing PatientProgram state transition error

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/ConversionUtil.java
@@ -321,23 +321,25 @@ public class ConversionUtil {
 		}
 		
 		// If the converter is a resource handler use the order of properties of its default representation
+		Set<String> alreadySetProperties = new HashSet<String>();
 		if (converter instanceof DelegatingResourceHandler) {
-			
+
 			DelegatingResourceHandler handler = (DelegatingResourceHandler) converter;
 			DelegatingResourceDescription resDesc = handler.getRepresentationDescription(new DefaultRepresentation());
-			
+
 			// Some resources do not have delegating resource description
 			if (resDesc != null) {
 				for (Map.Entry<String, Property> prop : resDesc.getProperties().entrySet()) {
 					if (map.containsKey(prop.getKey()) && !RestConstants.PROPERTY_FOR_TYPE.equals(prop.getKey())) {
 						converter.setProperty(ret, prop.getKey(), map.get(prop.getKey()));
+						alreadySetProperties.add(prop.getKey());
 					}
 				}
 			}
 		}
-		
+
 		for (Map.Entry<String, ?> prop : map.entrySet()) {
-			if (RestConstants.PROPERTY_FOR_TYPE.equals(prop.getKey()))
+			if (RestConstants.PROPERTY_FOR_TYPE.equals(prop.getKey()) || alreadySetProperties.contains(prop.getKey()))
 				continue;
 			converter.setProperty(ret, prop.getKey(), prop.getValue());
 		}

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtilTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtilTest.java
@@ -13,6 +13,8 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -21,17 +23,26 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.openmrs.User;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler;
+import org.openmrs.module.webservices.rest.web.response.ConversionException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class ConversionUtilTest extends BaseModuleWebContextSensitiveTest {
@@ -376,4 +387,100 @@ public class ConversionUtilTest extends BaseModuleWebContextSensitiveTest {
 	public class GreatGrandchildGenericType_Int extends GrandchildGenericType_Int {}
 	
 	public class ChildMultiGenericType extends BaseMultiGenericType<Integer, String, Temp> {}
+
+	@Test
+	@SuppressWarnings({ "rawtypes" })
+	public void convertMap_shouldCallSetPropertyOnlyOnceForPropertiesInDefaultRepresentation() throws Exception {
+		String expectedKey = "someKey";
+		String expectedValue = "someValue";
+		String expectedUUID = "12345";
+
+		Map<String, Object> mapToConvert = new HashMap<String, Object>();
+		mapToConvert.put(expectedKey, expectedValue);
+		mapToConvert.put(RestConstants.PROPERTY_UUID, expectedUUID);
+		mapToConvert.put(RestConstants.PROPERTY_FOR_TYPE, "someType");
+
+		DelegatingResourceHandler converter = (DelegatingResourceHandler) ConversionUtil.getConverter(DummyUser.class);
+		Assertions.assertNotNull(converter);
+
+		DelegatingResourceDescription representationDesc = converter.getRepresentationDescription(Representation.DEFAULT);
+		Map<String, DelegatingResourceDescription.Property> repDescProperties = new HashMap<String, DelegatingResourceDescription.Property>();
+		DelegatingResourceDescription.Property mockProperty = mock(DelegatingResourceDescription.Property.class);
+		repDescProperties.put(expectedKey, mockProperty);
+
+		when(representationDesc.getProperties()).thenReturn(repDescProperties);
+
+		DummyUser expectedUser = mock(DummyUser.class);
+		((DummyUserConverter) converter).addUser(expectedUUID, expectedUser);
+
+		DummyUser actualUser = (DummyUser) ConversionUtil.convertMap(mapToConvert, DummyUser.class);
+
+		Assertions.assertEquals(expectedUser, actualUser);
+		Assertions.assertEquals(1, (int) ((DummyUserConverter) converter).getPropertyKeyToNbTimesSet().get(expectedKey));
+	}
+
+	@Resource(name = "dummyUserConverter", supportedClass = DummyUser.class, supportedOpenmrsVersions = { "1.0.* - 9.*" })
+	public static class DummyUserConverter extends DelegatingCrudResource<DummyUser> {
+
+		private final DelegatingResourceDescription mockRepDesc = mock(DelegatingResourceDescription.class);
+
+		private final Map<String, Object> properties = new HashMap<String, Object>();
+
+		private final Map<String, Integer> propertyKeyToNbTimesSet = new HashMap<String, Integer>();
+
+		private final Map<String, DummyUser> uniqueIdToUser = new HashMap<String, DummyUser>();
+
+		public void addUser(String uniqueId, DummyUser user) {
+			uniqueIdToUser.put(uniqueId, user);
+		}
+
+		@Override
+		public void setProperty(Object instance, String propertyName, Object value) throws ConversionException {
+			properties.put(propertyName, value);
+			Integer nbTimesCalled = propertyKeyToNbTimesSet.get(propertyName);
+			propertyKeyToNbTimesSet.put(propertyName, nbTimesCalled == null ? 1 : nbTimesCalled + 1);
+		}
+
+		@Override
+		public DummyUser getByUniqueId(String uniqueId) {
+			return uniqueIdToUser.get(uniqueId);
+		}
+
+		@Override
+		public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+			return mockRepDesc;
+		}
+
+		@Override
+		protected void delete(DummyUser delegate, String reason, RequestContext context) throws ResponseException {
+			// Do nothing
+		}
+
+		@Override
+		public void purge(DummyUser delegate, RequestContext context) throws ResponseException {
+			// Do nothing
+		}
+
+		@Override
+		public DummyUser newDelegate() {
+			return null;
+		}
+
+		@Override
+		public DummyUser save(DummyUser delegate) {
+			return delegate;
+		}
+
+		public Map<String, Object> getProperties() {
+			return properties;
+		}
+
+		public Map<String, Integer> getPropertyKeyToNbTimesSet() {
+			return propertyKeyToNbTimesSet;
+		}
+	}
+
+	protected static class DummyUser extends User {
+		// No overrides needed
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
@@ -55,8 +55,8 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 			DelegatingResourceDescription description = new DelegatingResourceDescription();
 			description.addProperty("display");
 			description.addProperty("uuid");
-			description.addProperty("value");
 			description.addProperty("attributeType", Representation.REF);
+			description.addProperty("value");
 			description.addProperty("voided");
 			description.addSelfLink();
 			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8Test.java
@@ -188,13 +188,39 @@ public class PersonAttributeResource1_8Test extends BaseModuleWebContextSensitiv
 	public void setValue_shouldSetThePassedValueForNonAttributableClasses() throws ClassNotFoundException {
 		PersonAttributeType type = personService.getPersonAttributeTypeByName("Race");
 		PersonAttribute attribute = new PersonAttribute(type, null);
-		
+
 		Assertions.assertNull(attribute.getValue());
 		Assertions.assertEquals("java.lang.String", type.getFormat());
 		Assertions.assertFalse(Attributable.class.isAssignableFrom(Context.loadClass(type.getFormat())));
-		
+
 		resource.setValue(attribute, "arab");
-		
+
 		Assertions.assertEquals("arab", attribute.getValue());
+	}
+
+	@Test
+	public void create_shouldCorrectlyConvertCodedAttributeValueWhenCreatedViaConvertMap() throws Exception {
+		// Set up a Location-type attribute type
+		PersonAttributeType locationType = new PersonAttributeType();
+		locationType.setFormat("org.openmrs.Location");
+		locationType.setName("Coded Location Attribute");
+		locationType.setDescription("For testing coded attribute conversion");
+		locationType.setSearchable(false);
+		locationType = personService.savePersonAttributeType(locationType);
+
+		Location location = locationService.getAllLocations().get(0);
+
+		// Submit JSON with attributeType before value — matches DefaultRepresentation order after our fix
+		String json = "{\"attributeType\": {\"uuid\": \"" + locationType.getUuid() + "\"}, "
+		        + "\"value\": \"" + location.getUuid() + "\"}";
+
+		SimpleObject created = (SimpleObject) resource.create(
+		    "da7f524f-27ce-4bb2-86d6-6d1d05312bd5",
+		    SimpleObject.parseJson(json),
+		    new RequestContext());
+
+		// Value should be stored as location ID (serialized form), not the raw UUID
+		Assertions.assertNotNull(created.get("value"));
+		Assertions.assertNotEquals(location.getUuid(), created.get("value"));
 	}
 }


### PR DESCRIPTION
## Description of what I changed
Restored `alreadySetProperties` deduplication in `ConversionUtil.convertMap()` so that properties processed by Loop 1 (DefaultRepresentation order) are skipped by Loop 2, preventing `PatientProgram.states` from being set twice and triggering OpenMRS's state transition guard.

Also fixed property ordering in `PersonAttributeResource1_8` — moved `attributeType` before `value` in `DefaultRepresentation`. This was the root cause of the RESTWS-933 revert and is required for the deduplication fix to work correctly without breaking coded patient attributes.

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-971

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.
