### PR TITLE
O3-5539: Hide PHQ-9 encounters for patients under 18 at backend level

### DIFF
--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
@@ -294,6 +294,20 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 			if (patient == null)
 				return new EmptySearchResult();
 			List<Encounter> encs = Context.getEncounterService().getEncountersByPatient(patient);
+
+			encs = encs.stream()
+			    .filter(enc -> {
+			        if (enc.getPatient() != null && enc.getPatient().getAge() < 18) {
+			            if (enc.getForm() == null || enc.getForm().getName() == null) {
+			                return true;
+			            }
+			            String formName = enc.getForm().getName().toLowerCase();
+			            return !formName.contains("phq");
+			        }
+			        return true;
+			    })
+			    .collect(Collectors.toList());
+
 			return new NeedsPaging<Encounter>(encs, context);
 		}
 		

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
@@ -296,17 +296,21 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 			List<Encounter> encs = Context.getEncounterService().getEncountersByPatient(patient);
 
 			encs = encs.stream()
-			    .filter(enc -> {
-			        if (enc.getPatient() != null && enc.getPatient().getAge() < 18) {
-			            if (enc.getForm() == null || enc.getForm().getName() == null) {
-			                return true;
-			            }
-			            String formName = enc.getForm().getName().toLowerCase();
-			            return !formName.contains("phq");
-			        }
-			        return true;
-			    })
-			    .collect(Collectors.toList());
+    			.filter(enc -> {
+        			if (enc.getPatient() != null 
+            			&& enc.getPatient().getAge() != null 
+           	 			&& enc.getPatient().getAge() < 18) {
+
+            			if (enc.getForm() == null || enc.getForm().getName() == null) {
+                		return true;
+            			}
+
+            			String formName = enc.getForm().getName().toLowerCase();
+            			return !formName.contains("phq");
+        		}
+        		return true;
+    		})
+    		.collect(Collectors.toList());
 
 			return new NeedsPaging<Encounter>(encs, context);
 		}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->

## Description of what I changed
This PR implements backend filtering to hide PHQ-9 encounters for patients under 18 years of age.

Previously, this logic was handled at the frontend level. As per the requirement, it is now enforced at the backend so that all clients receive consistent data.

### Changes made:
- Added filtering logic in `EncounterResource1_8#doSearch`
- Filters encounters where:
  - Patient age is less than 18
  - Encounter form name contains "phq"
- Ensures PHQ-9 encounters are not returned for pediatric patients

This makes the behavior consistent across all consumers of the API and removes reliance on frontend filtering.


## Issue I worked on
see https://issues.openmrs.org/browse/O3-5539


## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.