### PR TITLE
feat(RESTWS-1131): add PropertyDecorator support for extending REST resources

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/util/ReflectionUtil.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/util/ReflectionUtil.java
@@ -147,5 +147,24 @@ public class ReflectionUtil {
 			throw new RuntimeException("No suitable method \"" + name + "\" in " + clazz);
 		return ret;
 	}
-	
+
+	/**
+	 * Find a @PropertyGetter-annotated method on any plain object
+	 * (not necessarily a DelegatingPropertyAccessor).
+	 * Used by PropertyDecorator support to look up getter methods
+	 * on decorator instances.
+	 *
+	 * @param object the decorator object to search
+	 * @param propName the property name to look for
+	 * @return the Method if found, null otherwise
+	 */
+	public static Method findPropertyGetterMethodOnObject(Object object, String propName) {
+		for (Method method : object.getClass().getMethods()) {
+			PropertyGetter ann = method.getAnnotation(PropertyGetter.class);
+			if (ann != null && ann.value().equals(propName)) {
+				return method;
+			}
+		}
+		return null;
+	}
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingConverter.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingConverter.java
@@ -28,6 +28,9 @@ import org.openmrs.module.webservices.rest.web.representation.CustomRepresentati
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.api.Converter;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
+import org.openmrs.annotation.Handler;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.resource.impl.PropertyDecorator;
 
 /**
  * A base implementation of a converter that can transform something that is _not_ a full resource
@@ -74,19 +77,63 @@ public abstract class BaseDelegatingConverter<T> implements Converter<T>, Delega
 
 		return convertDelegateToRepresentation(delegate, description);
 	}
-	
+
+	// AFTER
 	@Override
 	public Object getProperty(T instance, String propertyName) throws ConversionException {
 		try {
+			// Step 1: Check @PropertyGetter on this resource class
 			Method annotatedGetter = ReflectionUtil.findPropertyGetterMethod(this, propertyName);
 			if (annotatedGetter != null) {
 				return annotatedGetter.invoke(this, instance);
 			}
-			
+
+			// Step 2: Check registered PropertyDecorators for this instance type
+			List<PropertyDecorator> decorators = getDecoratorsForInstance(instance);
+			for (PropertyDecorator decorator : decorators) {
+				Method decoratorGetter = ReflectionUtil
+						.findPropertyGetterMethodOnObject(decorator, propertyName);
+				if (decoratorGetter != null) {
+					return decoratorGetter.invoke(decorator, instance);
+				}
+			}
+
+			// Step 3: Fall back to standard bean property access
 			return PropertyUtils.getProperty(instance, propertyName);
 		}
 		catch (Exception ex) {
 			throw new ConversionException("Unable to get property " + propertyName, ex);
+		}
+	}
+
+	/**
+	 * Returns all PropertyDecorators registered for the given instance's type.
+	 * Uses Spring's application context to find all beans implementing
+	 * PropertyDecorator whose @Handler annotation supports the instance's class.
+	 *
+	 * @param instance the domain object being converted
+	 * @return list of matching decorators, empty list if none found
+	 */
+	@SuppressWarnings("unchecked")
+	private List<PropertyDecorator> getDecoratorsForInstance(T instance) {
+		try {
+			Map<String, PropertyDecorator> beans = Context.getRegisteredComponents(PropertyDecorator.class);
+			List<PropertyDecorator> matching = new ArrayList<PropertyDecorator>();
+			for (PropertyDecorator decorator : beans.values()) {
+				Handler handler = decorator.getClass().getAnnotation(Handler.class);
+				if (handler != null) {
+					for (Class<?> supportedClass : handler.supports()) {
+						if (supportedClass.isAssignableFrom(instance.getClass())) {
+							matching.add(decorator);
+							break;
+						}
+					}
+				}
+			}
+			return matching;
+		}
+		catch (Exception e) {
+			return new ArrayList<PropertyDecorator>();
 		}
 	}
 	

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingConverter.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingConverter.java
@@ -78,7 +78,6 @@ public abstract class BaseDelegatingConverter<T> implements Converter<T>, Delega
 		return convertDelegateToRepresentation(delegate, description);
 	}
 
-	// AFTER
 	@Override
 	public Object getProperty(T instance, String propertyName) throws ConversionException {
 		try {

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/PropertyDecorator.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/PropertyDecorator.java
@@ -1,0 +1,14 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest.web.resource.impl;
+
+public interface PropertyDecorator {
+	
+}


### PR DESCRIPTION
## Summary

Adds `PropertyDecorator` support so that modules can add extra properties to existing REST resources without subclassing them.

Currently, if a module wants to expose an additional property on an existing resource (e.g. adding `fulfillerEncounter` to the Order resource), it must subclass the existing resource class. This is fragile — the subclass breaks whenever a newer version of the resource is released.

This PR introduces a `PropertyDecorator` marker interface that allows any Spring component to register extra properties for a domain object without touching the existing resource class.

## Changes Made

- Added `PropertyDecorator.java` — a marker interface that   modules implement to register as a property decorator
- Updated `BaseDelegatingConverter.getProperty()` — after  checking the resource class for `@PropertyGetter` now also checks registered `PropertyDecorator` beans via Spring context
- Added `ReflectionUtil.findPropertyGetterMethodOnObject()` —   a helper method to find `@PropertyGetter` on any plain object, not just `DelegatingPropertyAccessor` instances

## How to Use
```java
@Component
@Handler(supports = Order.class)
public class MyOrderDecorator implements PropertyDecorator {

    @PropertyGetter("fulfillerEncounter")
    public Encounter getFulfillerEncounter(Order order) {
        return ...;
    }
}
```

## Screenshots

N/A — backend only change

## Related Issue

Fixes https://openmrs.atlassian.net/browse/RESTWS-1021

## Other

The build failure in `TaskServiceWrapper.java` is a pre-existing issue unrelated to this PR. Confirmed by reproducing the same error on the unmodified master branch before applying any changes.