### PR TITLE
Fix JAXB dependency issue for integration tests on Java 11+

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -41,6 +41,18 @@
 			<artifactId>fluent-hc</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>4.0.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>4.0.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -49,7 +61,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.6.2</version>
+					<version>3.14.0</version>
 					<configuration>
 						<source>21</source>
 						<target>21</target>
@@ -58,7 +70,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.20</version>
+					<version>3.5.2</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
## Description of what I changed
Fixed build failures in the `integration-tests` module when running on Java 11+ (specifically Java 25). The issue was caused by the removal of `javax.xml.bind` (JAXB) from the standard JDK.

Technical changes:
- Updated `maven-compiler-plugin` to version **3.14.0** in `integration-tests/pom.xml`.
- Updated `maven-failsafe-plugin` to version **3.5.2** in `integration-tests/pom.xml` to support modern JDKs.
- Added `jakarta.xml.bind-api` (**4.0.0**) and `jaxb-impl` (**4.0.2**) as test dependencies.

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. (The fix targets existing tests)
- [x] I ran `mvn clean package` (or `mvn clean install`) right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**. (Fixes the environment for tests to run)
- [x] My pull request is **based on the latest changes** of the master branch.


