### PR TITLE
(fix) RESTWS-1027: Re-enable TaskServiceWrapper.runTask()

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/helper/TaskServiceWrapper.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/helper/TaskServiceWrapper.java
@@ -103,7 +103,6 @@ public class TaskServiceWrapper {
 	 * @throws SchedulerException - It will throw in case of any SchedulerService exceptions
 	 */
 	public void runTask(TaskDefinition taskDefinition) throws SchedulerException {
-		// see: https://openmrs.atlassian.net/browse/RESTWS-1032
-		throw new UnsupportedOperationException("Not supported.");
-    }
+		Context.getSchedulerService().schedule(taskDefinition);
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/VisitConfigurationController2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_0/VisitConfigurationController2_0.java
@@ -32,6 +32,7 @@ import org.openmrs.scheduler.TaskDefinition;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.PrivilegeConstants;
 import org.springframework.http.HttpStatus;
+import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -105,19 +106,28 @@ public class VisitConfigurationController2_0 extends BaseRestController {
 	}
 
 	private Boolean getAutoCloseVisitsTaskStartedValue(SchedulerService schedulerService) {
-		TaskDefinition autoCloseVisitsTaskStarted = schedulerService
-				.getTaskByName(OpenmrsConstants.AUTO_CLOSE_VISITS_TASK_NAME);
-
-		if (autoCloseVisitsTaskStarted != null) {
-			return autoCloseVisitsTaskStarted.getStarted();
+		try {
+			TaskDefinition autoCloseVisitsTaskStarted = schedulerService
+					.getTaskByName(OpenmrsConstants.AUTO_CLOSE_VISITS_TASK_NAME);
+			if (autoCloseVisitsTaskStarted != null) {
+				return autoCloseVisitsTaskStarted.getStarted();
+			}
 		}
-
+		catch (ObjectRetrievalFailureException e) {
+			// task not configured — treat as not started
+		}
 		return false;
 	}
 
 	private void updateGetAutoCloseVisitsTaskStartedValue(SchedulerService schedulerService,
 			Boolean autoCloseVisitsTaskStarted) throws SchedulerException {
-		TaskDefinition closeVisitsTask = schedulerService.getTaskByName(OpenmrsConstants.AUTO_CLOSE_VISITS_TASK_NAME);
+		TaskDefinition closeVisitsTask;
+		try {
+			closeVisitsTask = schedulerService.getTaskByName(OpenmrsConstants.AUTO_CLOSE_VISITS_TASK_NAME);
+		}
+		catch (ObjectRetrievalFailureException e) {
+			return;
+		}
 		if (closeVisitsTask != null) {
 			if (autoCloseVisitsTaskStarted && !closeVisitsTask.getStarted()) {
 				schedulerService.scheduleTask(closeVisitsTask);

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/MockTaskServiceWrapper.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/MockTaskServiceWrapper.java
@@ -11,6 +11,7 @@ package org.openmrs.module.webservices.rest.web;
 
 import org.openmrs.module.webservices.helper.TaskServiceWrapper;
 import org.openmrs.scheduler.SchedulerException;
+import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
 
 import java.util.ArrayList;
@@ -141,5 +142,18 @@ public class MockTaskServiceWrapper extends TaskServiceWrapper {
 		}
 		scheduledTasks.add(task);
 	}
-	
+
+	@Override
+	public void runTask(TaskDefinition taskDefinition) throws SchedulerException {
+		try {
+			Class<?> taskClass = Class.forName(taskDefinition.getTaskClass());
+			Task task = (Task) taskClass.getDeclaredConstructor().newInstance();
+			task.initialize(taskDefinition);
+			task.execute();
+		}
+		catch (Exception e) {
+			throw new SchedulerException("Failed to run task", e);
+		}
+	}
+
 }

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_4/TaskActionController2_4Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_4/TaskActionController2_4Test.java
@@ -96,8 +96,10 @@ public class TaskActionController2_4Test extends TaskActionController1_8Test {
 	public void shouldRunTask() throws Exception {
 		TaskDefinition taskDefinition = getTaskByUuid(CHRONIC_CARE_UUID);
 		taskDefinition.setTaskClass(DummyTask.class.getName());
-		// Set startTime far in the future to verify runTask() actually runs it relatively quickly
+		// startTime is 1 hour in the future — verifies runTask() ignores it and runs the task almost immediately (within 15 seconds)
 		taskDefinition.setStartTime(new Date(System.currentTimeMillis() + 3_600_000L));
+		// repeatInterval is 1s — verifies runTask() ignores it and runs the task exactly once
+		taskDefinition.setRepeatInterval(1L);
 		assertEquals(4, schedulerService.getRegisteredTasks().size());
 		int countBefore = count;
 		deserialize(handle(newPostRequest(getURI(),
@@ -112,6 +114,9 @@ public class TaskActionController2_4Test extends TaskActionController1_8Test {
 			Thread.sleep(200);
 		}
 		assertEquals(countBefore + 1, count, "Task should have run almost immediately despite future startTime");
+		// Wait longer than repeatInterval to verify the task did not repeat
+		Thread.sleep(2_000L);
+		assertEquals(countBefore + 1, count, "Task should have run exactly once (repeatInterval should be ignored)");
 	}
 
 	@Test

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_4/TaskActionController2_4Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs2_4/TaskActionController2_4Test.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
+
+import java.util.Date;
 import org.openmrs.module.webservices.helper.openmrs2_4.TaskServiceWrapper2_4;
 import org.openmrs.module.webservices.rest.web.api.RestService;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_8.TaskActionController1_8Test;
@@ -94,14 +96,22 @@ public class TaskActionController2_4Test extends TaskActionController1_8Test {
 	public void shouldRunTask() throws Exception {
 		TaskDefinition taskDefinition = getTaskByUuid(CHRONIC_CARE_UUID);
 		taskDefinition.setTaskClass(DummyTask.class.getName());
+		// Set startTime far in the future to verify runTask() actually runs it relatively quickly
+		taskDefinition.setStartTime(new Date(System.currentTimeMillis() + 3_600_000L));
 		assertEquals(4, schedulerService.getRegisteredTasks().size());
 		int countBefore = count;
 		deserialize(handle(newPostRequest(getURI(),
 				"{\"action\": \"runtask\", \"tasks\":[\"" + CHRONIC_CARE_UUID + "\"]}")));
 		assertThat(schedulerService.getRegisteredTasks(), hasItem(getTaskByUuid(CHRONIC_CARE_UUID)));
 		assertEquals(4, schedulerService.getRegisteredTasks().size());
-		int countAfter = count;
-		assertEquals(++countBefore, countAfter);
+		// Task runs asynchronously via JobRunr — poll until executed or timeout
+		// By default, JobRunr's BackgroundJobServer has a polling interval of 15 seconds, see:
+		// https://javadoc.io/static/org.jobrunr/jobrunr/5.3.2/org/jobrunr/server/BackgroundJobServerConfiguration.html#usingStandardBackgroundJobServerConfiguration()
+		long deadline = System.currentTimeMillis() + 15_000L;
+		while (count == countBefore && System.currentTimeMillis() < deadline) {
+			Thread.sleep(200);
+		}
+		assertEquals(countBefore + 1, count, "Task should have run almost immediately despite future startTime");
 	}
 
 	@Test


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
See https://github.com/openmrs/openmrs-module-webservices.rest/pull/731 for context. This PR fixes the TaskServiceWrapper.runTask() after core's migration to using JobRunr. Previously the `runTask()` function runs the task almost immediately. The the new implementation, `Context.getSchedulerService().schedule(taskDefinition)` calls JobRunr's `jobRequestScheduler.enqueue(job)`, which schedule the task for a "fire-and-forget" job; see [javadocs](https://repo.jobrunr.io/javadoc/releases/org/jobrunr/jobrunr-pro/latest/.cache/unpack/org/jobrunr/scheduling/JobRequestScheduler.html#enqueue(org.jobrunr.jobs.lambdas.JobRequest). That said, it's not an immediate run of the job. By default, JobRunr has a polling interval of 15 seconds, See [here](https://javadoc.io/static/org.jobrunr/jobrunr/5.3.2/org/jobrunr/server/BackgroundJobServerConfiguration.html#usingStandardBackgroundJobServerConfiguration()). It doesn't quite match the old behavior of firing right away, but given that it's a scheduled job, it's probably acceptable.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/RESTWS-1027

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

