### PR TITLE
Add Claude PR review caller workflow (pilot)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,11 +1,15 @@
 name: Claude PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:
   review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/claude-pr-review.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,23 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  review:
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/claude-pr-review.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      extra_instructions: |
+        This is a Java/Maven OpenMRS repository. Pay particular attention to:
+
+        - New Java files must include the license header from license-header.txt.
+        - For changes under src/main/**: flag missing @since tags on new public API, Hibernate/JPA misuse, missing @Transactional on data-modifying service methods, and any change to public API that could break downstream OpenMRS modules.
+        - For changes under src/test/**: tests must use JUnit 5 (org.junit.jupiter) and AssertJ/Hamcrest. Flag JUnit 4 imports in new tests. Prefer BaseContextSensitiveTest for integration tests needing a Spring context.
+        - For Liquibase changesets (**/liquibase/**/*.xml, **/liquibase-*.xml): changesets must be append-only — never edit an existing changeSet id/author. Flag any modification to historical changesets. New changesets need a unique id and author, and should include a rollback block where feasible.
+        - For Hibernate XML mappings (**/*.hbm.xml): OpenMRS is migrating to JPA annotations. Flag new mapping additions and suggest annotation-based equivalents on the @Entity class instead.
+        - For pom.xml: flag dependency version changes that bypass the BOM, additions of non-Apache-2.0-compatible licenses, and any new <repository> entries pointing outside Maven Central or OpenMRS infra.
+
+        This module exposes REST endpoints consumed by external clients. Flag breaking changes to existing endpoint shapes (request/response JSON), removed fields, or changed status codes — these affect downstream consumers and integrations.


### PR DESCRIPTION
## Summary

Adds a thin caller workflow that invokes the reusable Claude PR review workflow in `openmrs/openmrs-contrib-gha-workflows`. Triggers on `[opened, ready_for_review, reopened]` (no `synchronize`) to avoid re-reviewing on every push during the pilot.

## Why

Part of a 10-repo pilot of AI-assisted PR review (see openmrs/openmrs-contrib-gha-workflows#36). We're evaluating Claude Code Action as a potential replacement for CodeRabbit, which has been hitting free-tier limits.

## Dependencies

⚠️  **Do not merge before openmrs/openmrs-contrib-gha-workflows#36 is merged.** This PR is opened as a draft until then; the caller pins the reusable workflow to `@main`.

## Cost guardrails (pilot)

- Model: `claude-sonnet-4-6` (cheaper of the two main options).
- Trigger: `[opened, ready_for_review, reopened]` only — explicitly excludes `synchronize`, so each PR gets one review per state-change, not one per push.
- Skips draft PRs.

## Test plan

- [ ] Merge openmrs/openmrs-contrib-gha-workflows#36.
- [ ] Mark this PR ready for review.
- [ ] Verify the next non-draft PR opened against this repo gets a Claude review comment.
- [ ] Compare review quality / signal-to-noise vs. CodeRabbit over the next 1–2 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
