### PR TITLE
(fix) RESTWS-1035: Deduplicate concept results in memberOf and fuzzy search paths

### DIFF
--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -61,6 +61,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -601,6 +602,11 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 			if (memberOfList == null || memberOfList.contains(csr.getConcept()))
 				results.add(csr.getConcept());
 		}
+		
+		// Remove duplicate concepts that can arise from HQL joins on multi-valued associations
+		// (e.g., concept_name, concept_map) in the underlying queries. Uses LinkedHashSet to
+		// preserve insertion order while eliminating duplicates.
+		results = new ArrayList<Concept>(new LinkedHashSet<Concept>(results));
 		
 		PageableResult result = null;
 		if (canPage) {

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_8/ConceptSearchHandler1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/search/openmrs1_8/ConceptSearchHandler1_8.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -134,6 +135,8 @@ public class ConceptSearchHandler1_8 implements SearchHandler {
 			for (ConceptSearchResult csr : searchResults) {
 				results.add(csr.getConcept());
 			}
+			// Remove duplicates that can arise from HQL joins on multi-valued associations
+			results = new ArrayList<Concept>(new LinkedHashSet<Concept>(results));
 			return new NeedsPaging<Concept>(results, context);
 		} else if (searchType == null || "equals".equals(searchType)) {
 			

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_8Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ConceptController1_8Test.java
@@ -805,4 +805,47 @@ public class ConceptController1_8Test extends MainResourceControllerTest {
 		return concept;
 	}
 	
+	@Test
+	public void doSearch_shouldNotReturnDuplicateMembersOfConcept() throws Exception {
+		// Create a concept set with members that have multiple names, which can cause
+		// HQL joins to produce duplicate rows (RESTWS-1035)
+		Concept parentSet = newConcept("TEST PARENT SET");
+		parentSet.setSet(true);
+		
+		Concept member1 = newConcept("MEMBER ONE");
+		member1.addName(new ConceptName("MEMBER ONE SYNONYM", Locale.ENGLISH));
+		member1.addName(new ConceptName("MEMBRE UN", Locale.FRENCH));
+		
+		Concept member2 = newConcept("MEMBER TWO");
+		member2.addName(new ConceptName("MEMBER TWO SYNONYM", Locale.ENGLISH));
+		
+		service.saveConcept(member1);
+		service.saveConcept(member2);
+		
+		parentSet.addSetMember(member1);
+		parentSet.addSetMember(member2);
+		service.saveConcept(parentSet);
+		
+		// Query for members of the parent set
+		MockHttpServletRequest req = request(RequestMethod.GET, getURI());
+		req.addParameter("memberOf", parentSet.getUuid());
+		req.addParameter("q", "MEMBER");
+		
+		service.updateConceptIndexes();
+		
+		SimpleObject result = deserialize(handle(req));
+		List<Object> hits = (List<Object>) result.get("results");
+		
+		// Collect all returned UUIDs and verify uniqueness
+		java.util.Set<String> seenUuids = new java.util.HashSet<String>();
+		for (Object hit : hits) {
+			String uuid = (String) PropertyUtils.getProperty(hit, "uuid");
+			Assertions.assertTrue(seenUuids.add(uuid),
+			    "Duplicate concept UUID found in memberOf results: " + uuid);
+		}
+		
+		// We should have exactly 2 unique member concepts
+		Assertions.assertEquals(2, hits.size(), "Expected exactly 2 member concepts");
+	}
+	
 }


### PR DESCRIPTION
## Description of what I changed

The `doSearch()` method in `ConceptResource1_8.java` and the fuzzy search path in `ConceptSearchHandler1_8.java` never deduplicated their results lists. Both `getConceptsByConceptSet()` and `getConcepts()` can return duplicate `Concept` objects due to Hibernate JOIN FETCH on multi-valued associations (`concept_name`, `concept_map`), causing the REST response to contain the same concept multiple times.

### Root Cause
- `getConceptsByConceptSet()` uses an HQL query that joins on the `concept_set` table and can produce duplicate rows when a concept has multiple names or mappings
- `getConcepts()` similarly produces duplicates from joins on the `concept_name` table
- Neither the `memberOf`, `answerTo`, nor `q` search paths ever deduplicated the final results

### Changes Made

| File | Change |
|------|--------|
| `ConceptResource1_8.java` | Added `LinkedHashSet` deduplication after results list is built, covering `memberOf`, `answerTo`, and `q` search paths |
| `ConceptSearchHandler1_8.java` | Added the same `LinkedHashSet` dedup in the `fuzzy` searchType path |
| `ConceptController1_8Test.java` | Added `doSearch_shouldNotReturnDuplicateMembersOfConcept()` to assert no duplicate UUIDs are returned when querying `memberOf` |

### Why LinkedHashSet?
`LinkedHashSet` eliminates duplicates while preserving insertion order, making it the safest and most localized fix no upstream query behavior is changed.

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-1035

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.