### PR TITLE
Pin CI build to Java 21 until openmrs-core supports Java 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ concurrency:
 jobs:
   build:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/build-backend-module.yml@main
+    with:
+      # Pin to Java 21 (matches maven.compiler.target and release.yml). When java_versions is
+      # omitted the shared workflow infers the JDK from the platform dependency, which currently
+      # yields Java 25 — a version openmrs-core 3.0.0-SNAPSHOT cannot initialize (ServiceContext
+      # fails to load). Revisit once core supports Java 25.
+      java_versions: '[21]'
     secrets:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}


### PR DESCRIPTION
## Problem

`build / Build with Java 25` is failing on **master** and on **every open PR**. The root cause is not in this repo's code:

```
java.lang.NoClassDefFoundError: Could not initialize class org.openmrs.api.context.ServiceContext
(Caused by: NullPointerException — ServiceContext.log is null)
→ MetadataDelegatingCrudResourceTest, AlreadyPagedTest, NeedsPagingTest, RestServiceTest (omod-common)
```

openmrs-core `3.0.0-SNAPSHOT`'s `ServiceContext` fails to initialize under **Java 25** (a log4j2 custom-lookup NPE during static init), so the reactor dies in `omod-common` and `omod` is skipped entirely.

`build.yml` delegates to the shared `build-backend-module.yml`, which **infers the JDK from the platform dependency when `java_versions` is omitted** — and that inference now yields Java 25. The build was green until that inference changed (~Jun 12); master's last green run was Jun 3.

## Fix

Pin `java_versions: '[21]'` — the JDK this module compiles for (`maven.compiler.target=21`) and the one `release.yml` already uses. Verified locally: full `mvn -pl omod install` is green on Java 21.0.6 (1798 tests).

This is an interim pin; revisit once openmrs-core supports Java 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)