### PR TITLE
RESTWS-1038: Include obs uuid in the obstree response

### DIFF
--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ObsTreeResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ObsTreeResource1_9.java
@@ -171,6 +171,7 @@ public class ObsTreeResource1_9 extends BaseDelegatingResource<SimpleObject> imp
 			}
 			valueMap.put("value", value);
 			valueMap.put("obsDatetime", new SimpleDateFormat(DATETIME_FORMAT).format(obs.getObsDatetime()));
+			valueMap.put("uuid", obs.getUuid());
 			
 			if (concept.isNumeric()) {
 				if (obs.getInterpretation() != null) {

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsTreeController1_9Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_9/ObsTreeController1_9Test.java
@@ -11,8 +11,10 @@ package org.openmrs.module.webservices.rest.web.v1_0.controller.openmrs1_9;
 
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
@@ -84,6 +86,9 @@ public class ObsTreeController1_9Test extends MainResourceControllerTest {
 		// this entire hack is because timezone will differ between environments
 		replaceTimeZone(actualResult);
 		replaceTimeZone(expectedResult);
+		// uuid is asserted separately and dynamically in shouldGetObsTree_shouldIncludeUuidInEachObs;
+		// strip it here so this fixture-based comparison doesn't need to hardcode uuid values
+		removeUuid(actualResult);
 		Assertions.assertEquals(expectedResult, actualResult);
 	}
 
@@ -100,6 +105,61 @@ public class ObsTreeController1_9Test extends MainResourceControllerTest {
 				Iterator it = ((List) object.get(key)).iterator();
 				while (it.hasNext()) {
 					replaceTimeZone((HashMap) it.next());
+				}
+			}
+		}
+	}
+
+	// remove uuid keys recursively so this test can focus on the other obs fields
+	public void removeUuid(HashMap<String, Object> object) {
+		for (String key : new HashSet<>(object.keySet())) {
+			if (key.equals("uuid")) {
+				object.remove(key);
+			} else if (object.get(key) instanceof HashMap) {
+				removeUuid((HashMap) object.get(key));
+			} else if (object.get(key) instanceof List) {
+				Iterator it = ((List) object.get(key)).iterator();
+				while (it.hasNext()) {
+					Object item = it.next();
+					if (item instanceof HashMap) {
+						removeUuid((HashMap) item);
+					}
+				}
+			}
+		}
+	}
+
+	@Test
+	public void shouldGetObsTree_shouldIncludeUuidInEachObs() throws Exception {
+		MockHttpServletRequest req = newGetRequest(getURI(),
+				new Parameter("patient", "5946f880-b197-400b-9caa-a3c661d23041"),
+				new Parameter("concept", "0f97e14e-cdc2-49ac-9255-b5126f8a5148"));
+
+		SimpleObject result = deserialize(handle(req));
+
+		assertObsUuidsPresent(result);
+	}
+
+	private void assertObsUuidsPresent(Map<?, ?> node) {
+		if (node.containsKey("obs")) {
+			Object obsObject = node.get("obs");
+			if (obsObject instanceof List<?>) {
+				for (Object item : (List<?>) obsObject) {
+					if (item instanceof Map<?, ?>) {
+						Map<?, ?> obs = (Map<?, ?>) item;
+						Assertions.assertNotNull(obs.get("uuid"), "obs entry is missing uuid field");
+						Assertions.assertFalse(obs.get("uuid").toString().isEmpty(), "obs uuid should not be empty");
+					}
+				}
+			}
+		}
+		if (node.containsKey("subSets")) {
+			Object subSetsObject = node.get("subSets");
+			if (subSetsObject instanceof List<?>) {
+				for (Object item : (List<?>) subSetsObject) {
+					if (item instanceof Map<?, ?>) {
+						assertObsUuidsPresent((Map<?, ?>) item);
+					}
 				}
 			}
 		}

--- a/omod/src/test/resources/obsTreeDataset.json
+++ b/omod/src/test/resources/obsTreeDataset.json
@@ -10,7 +10,8 @@
           "value" : "7.0",
           "interpretation" : "NORMAL",
           "hiAbsolute" : 60.0,
-          "hiCritical" : 68.0
+          "hiCritical" : 68.0,
+          "uuid" : "a1521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "Numeric",
         "display" : "Hematocrit",
@@ -21,7 +22,8 @@
       }, {
         "obs" : [ {
           "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-          "value" : "8.0"
+          "value" : "8.0",
+          "uuid" : "b2521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "Numeric",
         "display" : "Platelets",
@@ -32,7 +34,8 @@
       }, {
         "obs" : [ {
           "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-          "value" : "9.0"
+          "value" : "9.0",
+          "uuid" : "c3521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "Numeric",
         "display" : "Haemoglobin",
@@ -43,7 +46,8 @@
       }, {
         "obs" : [ {
           "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-          "value" : "10.0"
+          "value" : "10.0",
+          "uuid" : "d4521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "Numeric",
         "display" : "White blood cells",
@@ -60,7 +64,8 @@
       "subSets" : [ {
         "obs" : [ {
           "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-          "value" : "62.0"
+          "value" : "62.0",
+          "uuid" : "aa521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "Numeric",
         "display" : "Serum Chloride",
@@ -68,7 +73,8 @@
       }, {
         "obs" : [ {
           "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-          "value" : "51.0"
+          "value" : "51.0",
+          "uuid" : "bb521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "Numeric",
         "display" : "Serum Carbon Dioxide",
@@ -76,7 +82,8 @@
       }, {
         "obs" : [ {
           "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-          "value" : "44.0"
+          "value" : "44.0",
+          "uuid" : "cc521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "Numeric",
         "display" : "Blood Urea Nitrogen",
@@ -93,7 +100,8 @@
     "subSets" : [ {
       "obs" : [ {
         "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-        "value" : "YES"
+        "value" : "YES",
+        "uuid" : "c6521c32-47b6-47da-9c6f-3673ddfb74f1"
       } ],
       "datatype" : "Coded",
       "display" : "CIVIL STATUS",
@@ -101,7 +109,8 @@
     }, {
       "obs" : [ {
         "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-        "value" : ""
+        "value" : "",
+        "uuid" : "d6521c32-47b6-47da-9c6f-3673ddfb74f1"
       } ],
       "datatype" : "N/A",
       "display" : "SINGLE",
@@ -111,7 +120,8 @@
       "subSets" : [ {
         "obs" : [ {
           "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-          "value" : ""
+          "value" : "",
+          "uuid" : "l6521c32-47b6-47da-9c6f-3673ddfb74f1"
         } ],
         "datatype" : "N/A",
         "display" : "MARRIED",
@@ -121,7 +131,8 @@
         "subSets" : [ {
           "obs" : [ {
             "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-            "value" : ""
+            "value" : "",
+            "uuid" : "s6521c32-47b6-47da-9c6f-3673ddfb74f1"
           } ],
           "datatype" : "N/A",
           "display" : "YES",
@@ -129,7 +140,8 @@
         }, {
           "obs" : [ {
             "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-            "value" : ""
+            "value" : "",
+            "uuid" : "x6521c32-47b6-47da-9c6f-3673ddfb74f1"
           } ],
           "datatype" : "N/A",
           "display" : "NO",
@@ -141,7 +153,8 @@
             "subSets" : [ {
               "obs" : [ {
                 "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-                "value" : ""
+                "value" : "",
+                "uuid" : "06521c32-47b6-47da-9c6f-3673ddfb74f1"
               } ],
               "datatype" : "N/A",
               "display" : "HIV PROGRAM",
@@ -157,7 +170,8 @@
   }, {
     "obs" : [ {
       "obsDatetime" : "2008-08-15T00:00:00.000+0200",
-      "value" : "PB and J"
+      "value" : "PB and J",
+      "uuid" : "e26cea2c-1b9f-4afe-b211-f3ef6c88af6f"
     } ],
     "datatype" : "Text",
     "display" : "FAVORITE FOOD, NON-CODED",


### PR DESCRIPTION
## Description of what I changed

The `ObsTreeResource1_9` (used by the `/ws/rest/v1/obstree` endpoint) builds a map for each observation in the tree containing `value`, `obsDatetime`, `interpretation`, and reference range fields, but did not include the observation's own `uuid`.

Without the `uuid`, clients (specifically the patient chart's test results viewer) cannot reliably distinguish:
- The same observation appearing in multiple branches of the tree (e.g. when configured root concept sets overlap, such as "Bloodwork" containing "Hematology"), from
- Two genuinely distinct observations that happen to share the same value and `obsDatetime` (e.g. one result per order, entered against the same encounter).

The frontend currently de-duplicates using an `obsDatetime` + `value` heuristic, which cannot tell these two cases apart.

This PR adds `obs.getUuid()` to the observation map in `ObsTreeResource1_9#getObsMap`, alongside the existing `value` and `obsDatetime` fields.

This change is additive and backwards compatible: existing consumers can simply ignore the new `uuid` field, while the frontend can switch its de-duplication identity to the obs `uuid` when present, falling back to its existing heuristic for older servers.

Related frontend PR: https://github.com/openmrs/openmrs-esm-patient-chart/pull/3374

## Issue I worked on

see https://issues.openmrs.org/browse/RESTWS-1038

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (Updated the expected fixture `obsTreeDataset.json` used by `ObsTreeController1_9Test#shouldGetObsTree` to assert the `uuid` field is present and correct for each observation.)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**. (`ObsTreeController1_9Test` passes; remaining unrelated failures on the full suite — `TaskActionController*`, `VisitConfigurationController2_0Test`, `CreatePatientIdentifierResource1_9Test` — are pre-existing and unaffected by this change.)
- [x] My pull request is **based on the latest changes** of the master branch.