### PR TITLE
RESTWS-1039: Support viewing archived observations introduced in TRUNK-6649

### DIFF
--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -574,7 +574,12 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 			if (enc == null)
 				return new EmptySearchResult();
 			
-			List<Obs> obs = new ArrayList<Obs>(enc.getAllObs(context.getIncludeAll()));
+			List<Obs> obs;
+			if (context.getIncludeAll()) {
+				obs = new ArrayList<Obs>(enc.getAllObsIncludingArchived());
+			} else {
+				obs = new ArrayList<Obs>(enc.getAllObs(false));
+			}
 			return new NeedsPaging<Obs>(obs, context);
 		}
 		

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -11,10 +11,14 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import org.openmrs.api.APIException;
+import org.openmrs.api.impl.ObsArchiveHelper;
+import org.openmrs.util.OpenmrsConstants;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -378,10 +382,23 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	 */
 	@PropertyGetter("groupMembers")
 	public static Object getGroupMembers(Obs obs) throws ConversionException {
-		if (obs.getGroupMembers() != null && !obs.getGroupMembers().isEmpty()) {
-			return obs.getGroupMembers();
+		Set<Obs> members = obs.getGroupMembers();
+		if (members == null) {
+			members = new LinkedHashSet<Obs>();
+		} else {
+			members = new LinkedHashSet<Obs>(members);
 		}
-		return null;
+
+		// Also include any archived children from obs_archive
+		ObsArchiveHelper archiveHelper = getObsArchiveHelperSafely();
+		if (archiveHelper != null && obs.getObsId() != null) {
+			List<Obs> archivedChildren = archiveHelper.getArchivedChildObs(obs.getObsId());
+			if (archivedChildren != null) {
+				members.addAll(archivedChildren);
+			}
+		}
+
+		return members.isEmpty() ? null : members;
 	}
 
 	/**
@@ -608,6 +625,20 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		obs = obsService.saveObs(obs, null);
 		
 		return (SimpleObject) ConversionUtil.convertToRepresentation(obs, Representation.DEFAULT);
+	}
+	
+	private static ObsArchiveHelper getObsArchiveHelperSafely() {
+		try {
+			String lastProcessedId = Context.getAdministrationService()
+					.getGlobalProperty(OpenmrsConstants.GP_OBS_ARCHIVE_LAST_PROCESSED_OBS_ID);
+			if (lastProcessedId != null && !lastProcessedId.trim().isEmpty()) {
+				return Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
+			}
+		}
+		catch (APIException e) {
+			// archive table may not exist yet or context not available, degrade gracefully
+		}
+		return null;
 	}
 	
 }


### PR DESCRIPTION

## Description of what I changed
This PR resolves an issue following the introduction of observation archiving in TRUNK-6649, where archived observations were missing from the REST API payload when querying an encounter with `includeAll=true` (e.g., when a user clicks "Toggle Deleted" in the UI).

## Specific changes include

- `ObsResource1_8.java`: Updated the resource logic to explicitly call the newly introduced `Encounter.getAllObsIncludingArchived()` method when includeAll is requested, instead of `Encounter.getAllObs()`. This ensures archived observations are successfully returned to the client.

## Issue I worked on
see https://issues.openmrs.org/browse/RESTWS-1039

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

