### PR TITLE
RESTWS-1043: Deprecate Swagger model getters in Resource classes

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -80,6 +80,10 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		return null;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = new ModelImpl();
@@ -309,6 +313,10 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		throw new ResourceDoesNotSupportOperationException();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return null;
@@ -332,6 +340,10 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		ModelImpl model = (ModelImpl) getCREATEModel(rep);

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingResource.java
@@ -81,7 +81,7 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -314,7 +314,7 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -341,7 +341,7 @@ public abstract class BaseDelegatingResource<T> extends BaseDelegatingConverter<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
@@ -78,7 +78,7 @@ public abstract class BaseDelegatingSubclassHandler<Superclass, Subclass extends
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/BaseDelegatingSubclassHandler.java
@@ -77,6 +77,10 @@ public abstract class BaseDelegatingSubclassHandler<Superclass, Subclass extends
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingResourceHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingResourceHandler.java
@@ -98,7 +98,9 @@ public interface DelegatingResourceHandler<T> extends DelegatingPropertyAccessor
 	 *            {@link Representation#FULL}
 	 * @return a {@link Model} object or null in case if such model does not exist or not
 	 *         documented.
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
+	@Deprecated
 	Model getGETModel(Representation rep);
 	
 	/**
@@ -110,7 +112,9 @@ public interface DelegatingResourceHandler<T> extends DelegatingPropertyAccessor
 	 *            can take {@link Representation#DEFAULT}, or {@link Representation#FULL}
 	 * @return a {@link Model} object or null in case if such model does not exist or not
 	 *         documented.
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
+	@Deprecated
 	Model getCREATEModel(Representation rep);
 	
 	/**
@@ -122,6 +126,8 @@ public interface DelegatingResourceHandler<T> extends DelegatingPropertyAccessor
 	 *            can take {@link Representation#DEFAULT}, or {@link Representation#FULL}
 	 * @return a {@link Model} object or null in case if such model does not exist or not
 	 *         documented.
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
+	@Deprecated
 	Model getUPDATEModel(Representation rep);
 }

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingResourceHandler.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/DelegatingResourceHandler.java
@@ -98,7 +98,7 @@ public interface DelegatingResourceHandler<T> extends DelegatingPropertyAccessor
 	 *            {@link Representation#FULL}
 	 * @return a {@link Model} object or null in case if such model does not exist or not
 	 *         documented.
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	Model getGETModel(Representation rep);
@@ -112,7 +112,7 @@ public interface DelegatingResourceHandler<T> extends DelegatingPropertyAccessor
 	 *            can take {@link Representation#DEFAULT}, or {@link Representation#FULL}
 	 * @return a {@link Model} object or null in case if such model does not exist or not
 	 *         documented.
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	Model getCREATEModel(Representation rep);
@@ -126,7 +126,7 @@ public interface DelegatingResourceHandler<T> extends DelegatingPropertyAccessor
 	 *            can take {@link Representation#DEFAULT}, or {@link Representation#FULL}
 	 * @return a {@link Model} object or null in case if such model does not exist or not
 	 *         documented.
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	Model getUPDATEModel(Representation rep);

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
@@ -38,6 +38,10 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
  */
 public abstract class MetadataDelegatingCrudResource<T extends OpenmrsMetadata> extends DelegatingCrudResource<T> {
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
@@ -52,6 +56,10 @@ public abstract class MetadataDelegatingCrudResource<T extends OpenmrsMetadata> 
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/resource/impl/MetadataDelegatingCrudResource.java
@@ -39,7 +39,7 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 public abstract class MetadataDelegatingCrudResource<T extends OpenmrsMetadata> extends DelegatingCrudResource<T> {
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -57,7 +57,7 @@ public abstract class MetadataDelegatingCrudResource<T extends OpenmrsMetadata> 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/helper/LayoutTemplateRepresentation.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/helper/LayoutTemplateRepresentation.java
@@ -36,6 +36,10 @@ public class LayoutTemplateRepresentation {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public static ModelImpl getGETModel(Class<? extends Enum<?>> clsTokenEnum) {
 		return new ModelImpl()
 				.property("displayName", new StringProperty())

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/helper/LayoutTemplateRepresentation.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/helper/LayoutTemplateRepresentation.java
@@ -37,7 +37,7 @@ public class LayoutTemplateRepresentation {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public static ModelImpl getGETModel(Class<? extends Enum<?>> clsTokenEnum) {

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/CareSettingResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/CareSettingResource1_10.java
@@ -77,7 +77,7 @@ public class CareSettingResource1_10 extends MetadataDelegatingCrudResource<Care
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/CareSettingResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/CareSettingResource1_10.java
@@ -76,6 +76,10 @@ public class CareSettingResource1_10 extends MetadataDelegatingCrudResource<Care
 		throw new ResourceDoesNotSupportOperationException();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugReferenceMapResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugReferenceMapResource1_10.java
@@ -119,7 +119,7 @@ public class DrugReferenceMapResource1_10 extends DelegatingCrudResource<DrugRef
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -139,7 +139,7 @@ public class DrugReferenceMapResource1_10 extends DelegatingCrudResource<DrugRef
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugReferenceMapResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugReferenceMapResource1_10.java
@@ -118,6 +118,10 @@ public class DrugReferenceMapResource1_10 extends DelegatingCrudResource<DrugRef
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation) {
@@ -134,6 +138,10 @@ public class DrugReferenceMapResource1_10 extends DelegatingCrudResource<DrugRef
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl().property("conceptReferenceTerm", new StringProperty().example("uuid"))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugResource1_10.java
@@ -61,7 +61,7 @@ public class DrugResource1_10 extends DrugResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -77,7 +77,7 @@ public class DrugResource1_10 extends DrugResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/DrugResource1_10.java
@@ -60,6 +60,10 @@ public class DrugResource1_10 extends DrugResource1_8 {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation) {
@@ -72,6 +76,10 @@ public class DrugResource1_10 extends DrugResource1_8 {
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10.java
@@ -115,7 +115,7 @@ public class OrderResource1_10 extends OrderResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderResource1_10.java
@@ -114,6 +114,10 @@ public class OrderResource1_10 extends OrderResource1_8 {
 		}
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderTypeResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderTypeResource1_10.java
@@ -159,7 +159,7 @@ public class OrderTypeResource1_10 extends MetadataDelegatingCrudResource<OrderT
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -182,7 +182,7 @@ public class OrderTypeResource1_10 extends MetadataDelegatingCrudResource<OrderT
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderTypeResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderTypeResource1_10.java
@@ -158,6 +158,10 @@ public class OrderTypeResource1_10 extends MetadataDelegatingCrudResource<OrderT
 		return d;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -177,6 +181,10 @@ public class OrderTypeResource1_10 extends MetadataDelegatingCrudResource<OrderT
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/PersonResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/PersonResource1_10.java
@@ -60,7 +60,7 @@ public class PersonResource1_10 extends PersonResource1_8 {
 		return description;
 	}
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -69,7 +69,7 @@ public class PersonResource1_10 extends PersonResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -78,7 +78,7 @@ public class PersonResource1_10 extends PersonResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/PersonResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/PersonResource1_10.java
@@ -59,16 +59,28 @@ public class PersonResource1_10 extends PersonResource1_8 {
 		description.addProperty("birthtime");
 		return description;
 	}
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		return addNewProperties(super.getGETModel(rep), rep);
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return addNewProperties(super.getCREATEModel(rep), rep);
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return addNewProperties(super.getUPDATEModel(rep), rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramEnrollmentResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramEnrollmentResource1_10.java
@@ -99,6 +99,10 @@ public class ProgramEnrollmentResource1_10 extends ProgramEnrollmentResource1_8 
 		return d;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -106,6 +110,10 @@ public class ProgramEnrollmentResource1_10 extends ProgramEnrollmentResource1_8 
 		        .property("outcome", new RefProperty("#/definitions/ConceptCreate"));
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl() //FIXME use super.

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramEnrollmentResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramEnrollmentResource1_10.java
@@ -100,7 +100,7 @@ public class ProgramEnrollmentResource1_10 extends ProgramEnrollmentResource1_8 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -111,7 +111,7 @@ public class ProgramEnrollmentResource1_10 extends ProgramEnrollmentResource1_8 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramResource1_10.java
@@ -66,6 +66,10 @@ public class ProgramResource1_10 extends ProgramResource1_8 {
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/ProgramResource1_10.java
@@ -67,7 +67,7 @@ public class ProgramResource1_10 extends ProgramResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
@@ -130,7 +130,7 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -156,7 +156,7 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -173,7 +173,7 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/TestOrderSubclassHandler1_10.java
@@ -129,6 +129,10 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 		return orderResource.getUpdatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		OrderResource1_10 orderResource = (OrderResource1_10) Context.getService(RestService.class)
@@ -151,6 +155,10 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 		return orderModel;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		OrderResource1_10 orderResource = (OrderResource1_10) Context.getService(RestService.class)
@@ -164,6 +172,10 @@ public class TestOrderSubclassHandler1_10 extends BaseDelegatingSubclassHandler<
 		        .property("numberOfRepeats", new IntegerProperty());
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		OrderResource1_10 orderResource = (OrderResource1_10) Context.getService(RestService.class)

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
@@ -85,6 +85,10 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -106,6 +110,10 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -116,6 +124,10 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 		        .required("ingredient");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/DrugIngredientResource1_11.java
@@ -86,7 +86,7 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -111,7 +111,7 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -125,7 +125,7 @@ public class DrugIngredientResource1_11 extends DelegatingSubResource<DrugIngred
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/ObsResource1_11.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/ObsResource1_11.java
@@ -43,7 +43,7 @@ public class ObsResource1_11 extends ObsResource1_9 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -54,7 +54,7 @@ public class ObsResource1_11 extends ObsResource1_9 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/ObsResource1_11.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/ObsResource1_11.java
@@ -42,6 +42,10 @@ public class ObsResource1_11 extends ObsResource1_9 {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		return ((ModelImpl) super.getGETModel(rep))
@@ -49,6 +53,10 @@ public class ObsResource1_11 extends ObsResource1_9 {
 		        .property("formFieldNamespace", new StringProperty());
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/PersonResource1_11.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/PersonResource1_11.java
@@ -63,16 +63,28 @@ public class PersonResource1_11 extends PersonResource1_10 {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		return addNewProperties(super.getGETModel(rep), rep);
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return addNewProperties(super.getCREATEModel(rep), rep);
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return addNewProperties(super.getUPDATEModel(rep), rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/PersonResource1_11.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_11/PersonResource1_11.java
@@ -64,7 +64,7 @@ public class PersonResource1_11 extends PersonResource1_10 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -73,7 +73,7 @@ public class PersonResource1_11 extends PersonResource1_10 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -82,7 +82,7 @@ public class PersonResource1_11 extends PersonResource1_10 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderGroupResource1_12.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderGroupResource1_12.java
@@ -129,7 +129,7 @@ public class OrderGroupResource1_12 extends DataDelegatingCrudResource<OrderGrou
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -158,7 +158,7 @@ public class OrderGroupResource1_12 extends DataDelegatingCrudResource<OrderGrou
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -170,7 +170,7 @@ public class OrderGroupResource1_12 extends DataDelegatingCrudResource<OrderGrou
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderGroupResource1_12.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderGroupResource1_12.java
@@ -128,6 +128,10 @@ public class OrderGroupResource1_12 extends DataDelegatingCrudResource<OrderGrou
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -153,6 +157,10 @@ public class OrderGroupResource1_12 extends DataDelegatingCrudResource<OrderGrou
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		return new ModelImpl().property("patient", new StringProperty().example("uuid"))
@@ -161,6 +169,10 @@ public class OrderGroupResource1_12 extends DataDelegatingCrudResource<OrderGrou
 		        .property("orderSet", new StringProperty().example("uuid"));
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl().property("orders",

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
@@ -105,7 +105,7 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -132,7 +132,7 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -146,7 +146,7 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetMemberResource1_12.java
@@ -104,6 +104,10 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -127,6 +131,10 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -137,6 +145,10 @@ public class OrderSetMemberResource1_12 extends DelegatingSubResource<OrderSetMe
 		        .property("retired", new BooleanProperty());
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
@@ -114,6 +114,10 @@ public class OrderSetResource1_12 extends MetadataDelegatingCrudResource<OrderSe
 		return d;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -133,6 +137,10 @@ public class OrderSetResource1_12 extends MetadataDelegatingCrudResource<OrderSe
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_12/OrderSetResource1_12.java
@@ -115,7 +115,7 @@ public class OrderSetResource1_12 extends MetadataDelegatingCrudResource<OrderSe
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -138,7 +138,7 @@ public class OrderSetResource1_12 extends MetadataDelegatingCrudResource<OrderSe
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8.java
@@ -98,7 +98,7 @@ public class CohortResource1_8 extends DataDelegatingCrudResource<Cohort> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -116,7 +116,7 @@ public class CohortResource1_8 extends DataDelegatingCrudResource<Cohort> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -129,7 +129,7 @@ public class CohortResource1_8 extends DataDelegatingCrudResource<Cohort> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/CohortResource1_8.java
@@ -97,6 +97,10 @@ public class CohortResource1_8 extends DataDelegatingCrudResource<Cohort> {
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -111,6 +115,10 @@ public class CohortResource1_8 extends DataDelegatingCrudResource<Cohort> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -120,6 +128,10 @@ public class CohortResource1_8 extends DataDelegatingCrudResource<Cohort> {
 		        .required("name").required("description").required("memberIds");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8.java
@@ -73,6 +73,10 @@ public class ConceptClassResource1_8 extends MetadataDelegatingCrudResource<Conc
 		Context.getConceptService().purgeConceptClass(conceptClass);
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptClassResource1_8.java
@@ -74,7 +74,7 @@ public class ConceptClassResource1_8 extends MetadataDelegatingCrudResource<Conc
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8.java
@@ -74,7 +74,7 @@ public class ConceptDatatypeResource1_8 extends MetadataDelegatingCrudResource<C
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDatatypeResource1_8.java
@@ -73,6 +73,10 @@ public class ConceptDatatypeResource1_8 extends MetadataDelegatingCrudResource<C
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
@@ -67,6 +67,10 @@ public class ConceptDescriptionResource1_8 extends DelegatingSubResource<Concept
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof RefRepresentation) {
@@ -89,6 +93,10 @@ public class ConceptDescriptionResource1_8 extends DelegatingSubResource<Concept
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptDescriptionResource1_8.java
@@ -68,7 +68,7 @@ public class ConceptDescriptionResource1_8 extends DelegatingSubResource<Concept
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -94,7 +94,7 @@ public class ConceptDescriptionResource1_8 extends DelegatingSubResource<Concept
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptMapResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptMapResource1_8.java
@@ -66,7 +66,7 @@ public class ConceptMapResource1_8 extends DelegatingSubResource<ConceptMap, Con
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -89,7 +89,7 @@ public class ConceptMapResource1_8 extends DelegatingSubResource<ConceptMap, Con
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptMapResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptMapResource1_8.java
@@ -65,6 +65,10 @@ public class ConceptMapResource1_8 extends DelegatingSubResource<ConceptMap, Con
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation) {
@@ -84,6 +88,10 @@ public class ConceptMapResource1_8 extends DelegatingSubResource<ConceptMap, Con
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptNameResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptNameResource1_8.java
@@ -70,6 +70,10 @@ public class ConceptNameResource1_8 extends DelegatingSubResource<ConceptName, C
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
 		        .property("uuid", new StringProperty())
@@ -85,6 +89,10 @@ public class ConceptNameResource1_8 extends DelegatingSubResource<ConceptName, C
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -95,6 +103,10 @@ public class ConceptNameResource1_8 extends DelegatingSubResource<ConceptName, C
 		        .required("name").required("locale");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptNameResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptNameResource1_8.java
@@ -71,7 +71,7 @@ public class ConceptNameResource1_8 extends DelegatingSubResource<ConceptName, C
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -90,7 +90,7 @@ public class ConceptNameResource1_8 extends DelegatingSubResource<ConceptName, C
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -104,7 +104,7 @@ public class ConceptNameResource1_8 extends DelegatingSubResource<ConceptName, C
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -241,6 +241,10 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
 		        .property("uuid", new StringProperty())
@@ -277,6 +281,10 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -314,6 +322,10 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptResource1_8.java
@@ -242,7 +242,7 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -282,7 +282,7 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -323,7 +323,7 @@ public class ConceptResource1_8 extends DelegatingCrudResource<Concept> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8.java
@@ -77,7 +77,7 @@ public class ConceptSourceResource1_8 extends MetadataDelegatingCrudResource<Con
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -91,7 +91,7 @@ public class ConceptSourceResource1_8 extends MetadataDelegatingCrudResource<Con
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ConceptSourceResource1_8.java
@@ -76,6 +76,10 @@ public class ConceptSourceResource1_8 extends MetadataDelegatingCrudResource<Con
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		return ((ModelImpl) super.getGETModel(rep))
 		        .property("uuid", new StringProperty())
@@ -86,6 +90,10 @@ public class ConceptSourceResource1_8 extends MetadataDelegatingCrudResource<Con
 		        .property("retired", new BooleanProperty());
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
@@ -133,7 +133,7 @@ public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<O
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -160,7 +160,7 @@ public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<O
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugOrderSubclassHandler1_8.java
@@ -132,6 +132,10 @@ public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<O
 		return d;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		OrderResource1_8 orderResource = (OrderResource1_8) Context.getService(RestService.class)
@@ -155,6 +159,10 @@ public class DrugOrderSubclassHandler1_8 extends BaseDelegatingSubclassHandler<O
 		return orderModel;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		OrderResource1_8 orderResource = (OrderResource1_8) Context.getService(RestService.class)

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugResource1_8.java
@@ -125,6 +125,10 @@ public class DrugResource1_8 extends MetadataDelegatingCrudResource<Drug> {
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -149,6 +153,10 @@ public class DrugResource1_8 extends MetadataDelegatingCrudResource<Drug> {
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
@@ -171,6 +179,10 @@ public class DrugResource1_8 extends MetadataDelegatingCrudResource<Drug> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep); //FIXME no updatableProperties()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/DrugResource1_8.java
@@ -126,7 +126,7 @@ public class DrugResource1_8 extends MetadataDelegatingCrudResource<Drug> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -154,7 +154,7 @@ public class DrugResource1_8 extends MetadataDelegatingCrudResource<Drug> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -180,7 +180,7 @@ public class DrugResource1_8 extends MetadataDelegatingCrudResource<Drug> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
@@ -98,6 +98,10 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -128,6 +132,10 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -143,6 +151,10 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 		        .required("patient").required("encounterType");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterResource1_8.java
@@ -99,7 +99,7 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -133,7 +133,7 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -152,7 +152,7 @@ public class EncounterResource1_8 extends DataDelegatingCrudResource<Encounter> 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8.java
@@ -50,7 +50,7 @@ public class EncounterTypeResource1_8 extends MetadataDelegatingCrudResource<Enc
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/EncounterTypeResource1_8.java
@@ -49,6 +49,10 @@ public class EncounterTypeResource1_8 extends MetadataDelegatingCrudResource<Enc
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
@@ -81,7 +81,7 @@ public class FieldAnswerResource1_8 extends DelegatingSubResource<FieldAnswer, F
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -103,7 +103,7 @@ public class FieldAnswerResource1_8 extends DelegatingSubResource<FieldAnswer, F
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldAnswerResource1_8.java
@@ -80,6 +80,10 @@ public class FieldAnswerResource1_8 extends DelegatingSubResource<FieldAnswer, F
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation) {
@@ -98,6 +102,10 @@ public class FieldAnswerResource1_8 extends DelegatingSubResource<FieldAnswer, F
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8.java
@@ -36,6 +36,10 @@ import java.util.List;
 @Resource(name = RestConstants.VERSION_1 + "/field", supportedClass = Field.class, supportedOpenmrsVersions = { "1.8.* - 9.*" })
 public class FieldResource1_8 extends MetadataDelegatingCrudResource<Field> {
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -57,6 +61,10 @@ public class FieldResource1_8 extends MetadataDelegatingCrudResource<Field> {
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -70,6 +78,10 @@ public class FieldResource1_8 extends MetadataDelegatingCrudResource<Field> {
 		        .required("fieldType").required("selectMultiple");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation representation) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldResource1_8.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class FieldResource1_8 extends MetadataDelegatingCrudResource<Field> {
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -62,7 +62,7 @@ public class FieldResource1_8 extends MetadataDelegatingCrudResource<Field> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -79,7 +79,7 @@ public class FieldResource1_8 extends MetadataDelegatingCrudResource<Field> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
@@ -38,6 +38,10 @@ public class FieldTypeResource1_8 extends MetadataDelegatingCrudResource<FieldTy
 		return PrivilegeConstants.GET_FIELD_TYPES;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -47,6 +51,10 @@ public class FieldTypeResource1_8 extends MetadataDelegatingCrudResource<FieldTy
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FieldTypeResource1_8.java
@@ -39,7 +39,7 @@ public class FieldTypeResource1_8 extends MetadataDelegatingCrudResource<FieldTy
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -52,7 +52,7 @@ public class FieldTypeResource1_8 extends MetadataDelegatingCrudResource<FieldTy
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
@@ -43,7 +43,7 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form, FormResource1_8> {
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -76,7 +76,7 @@ public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -104,7 +104,7 @@ public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormFieldResource1_8.java
@@ -42,6 +42,10 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
         "1.8.* - 9.*" })
 public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form, FormResource1_8> {
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -71,6 +75,10 @@ public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form,
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl() //FIXME validate if correct
@@ -95,6 +103,10 @@ public class FormFieldResource1_8 extends DelegatingSubResource<FormField, Form,
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8.java
@@ -101,6 +101,10 @@ public class FormResource1_8 extends MetadataDelegatingCrudResource<Form> {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -127,6 +131,10 @@ public class FormResource1_8 extends MetadataDelegatingCrudResource<Form> {
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
@@ -147,6 +155,10 @@ public class FormResource1_8 extends MetadataDelegatingCrudResource<Form> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/FormResource1_8.java
@@ -102,7 +102,7 @@ public class FormResource1_8 extends MetadataDelegatingCrudResource<Form> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -132,7 +132,7 @@ public class FormResource1_8 extends MetadataDelegatingCrudResource<Form> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -156,7 +156,7 @@ public class FormResource1_8 extends MetadataDelegatingCrudResource<Form> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
@@ -96,7 +96,7 @@ public class HL7MessageResource1_8 extends DataDelegatingCrudResource<IncomingHl
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -120,7 +120,7 @@ public class HL7MessageResource1_8 extends DataDelegatingCrudResource<IncomingHl
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7MessageResource1_8.java
@@ -95,6 +95,10 @@ public class HL7MessageResource1_8 extends DataDelegatingCrudResource<IncomingHl
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -115,6 +119,10 @@ public class HL7MessageResource1_8 extends DataDelegatingCrudResource<IncomingHl
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8.java
@@ -64,7 +64,7 @@ public class HL7SourceResource1_8 extends MetadataDelegatingCrudResource<HL7Sour
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -75,7 +75,7 @@ public class HL7SourceResource1_8 extends MetadataDelegatingCrudResource<HL7Sour
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/HL7SourceResource1_8.java
@@ -63,6 +63,10 @@ public class HL7SourceResource1_8 extends MetadataDelegatingCrudResource<HL7Sour
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -70,6 +74,10 @@ public class HL7SourceResource1_8 extends MetadataDelegatingCrudResource<HL7Sour
 		        .required("description");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationResource1_8.java
@@ -149,7 +149,7 @@ public class LocationResource1_8 extends MetadataDelegatingCrudResource<Location
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -186,7 +186,7 @@ public class LocationResource1_8 extends MetadataDelegatingCrudResource<Location
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -211,7 +211,7 @@ public class LocationResource1_8 extends MetadataDelegatingCrudResource<Location
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationResource1_8.java
@@ -148,6 +148,10 @@ public class LocationResource1_8 extends MetadataDelegatingCrudResource<Location
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -181,6 +185,10 @@ public class LocationResource1_8 extends MetadataDelegatingCrudResource<Location
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -202,6 +210,10 @@ public class LocationResource1_8 extends MetadataDelegatingCrudResource<Location
 		        .property("childLocations", new ArrayProperty(new StringProperty()));
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationTagResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationTagResource1_8.java
@@ -99,6 +99,10 @@ public class LocationTagResource1_8 extends MetadataDelegatingCrudResource<Locat
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationTagResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/LocationTagResource1_8.java
@@ -100,7 +100,7 @@ public class LocationTagResource1_8 extends MetadataDelegatingCrudResource<Locat
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleActionResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleActionResource1_8.java
@@ -296,6 +296,10 @@ public class ModuleActionResource1_8 extends BaseDelegatingResource<ModuleAction
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		return ((ModelImpl) super.getGETModel(rep))
@@ -303,6 +307,10 @@ public class ModuleActionResource1_8 extends BaseDelegatingResource<ModuleAction
 		        .property("action", new EnumProperty(Action.class));
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleActionResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleActionResource1_8.java
@@ -297,7 +297,7 @@ public class ModuleActionResource1_8 extends BaseDelegatingResource<ModuleAction
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -308,7 +308,7 @@ public class ModuleActionResource1_8 extends BaseDelegatingResource<ModuleAction
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
@@ -108,7 +108,7 @@ public class ModuleResource1_8 extends BaseDelegatingReadableResource<Module> im
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ModuleResource1_8.java
@@ -107,6 +107,10 @@ public class ModuleResource1_8 extends BaseDelegatingReadableResource<Module> im
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -193,6 +193,10 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -224,6 +228,10 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl().property("person", new StringProperty().example("uuid"))
@@ -238,6 +246,10 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 		        .required("person").required("obsDatetime").required("concept");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -194,7 +194,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -229,7 +229,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -247,7 +247,7 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
@@ -206,6 +206,10 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 		return d;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -243,6 +247,10 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -275,6 +283,10 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/OrderResource1_8.java
@@ -207,7 +207,7 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -248,7 +248,7 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -284,7 +284,7 @@ public class OrderResource1_8 extends DataDelegatingCrudResource<Order> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
@@ -135,6 +135,10 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -158,6 +162,10 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -175,6 +183,10 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierResource1_8.java
@@ -136,7 +136,7 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -163,7 +163,7 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -184,7 +184,7 @@ public class PatientIdentifierResource1_8 extends DelegatingSubResource<PatientI
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8.java
@@ -122,7 +122,7 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -142,7 +142,7 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -158,7 +158,7 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientIdentifierTypeResource1_8.java
@@ -121,6 +121,10 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -137,6 +141,10 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -149,6 +157,10 @@ public class PatientIdentifierTypeResource1_8 extends MetadataDelegatingCrudReso
 		        .property("uniquenessBehavior", new StringProperty()); //FIXME check type
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
@@ -149,7 +149,7 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -175,7 +175,7 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -193,7 +193,7 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientResource1_8.java
@@ -148,6 +148,10 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -170,6 +174,10 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -184,6 +192,10 @@ public class PatientResource1_8 extends DataDelegatingCrudResource<Patient> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientStateResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientStateResource1_8.java
@@ -176,6 +176,10 @@ public class PatientStateResource1_8 extends DelegatingSubResource<PatientState,
 		return updatableProperties;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -201,6 +205,10 @@ public class PatientStateResource1_8 extends DelegatingSubResource<PatientState,
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -209,6 +217,10 @@ public class PatientStateResource1_8 extends DelegatingSubResource<PatientState,
 		        .required("state");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientStateResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PatientStateResource1_8.java
@@ -177,7 +177,7 @@ public class PatientStateResource1_8 extends DelegatingSubResource<PatientState,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -206,7 +206,7 @@ public class PatientStateResource1_8 extends DelegatingSubResource<PatientState,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -218,7 +218,7 @@ public class PatientStateResource1_8 extends DelegatingSubResource<PatientState,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8.java
@@ -140,6 +140,10 @@ public class PersonAddressResource1_8 extends DelegatingSubResource<PersonAddres
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep))
@@ -169,6 +173,10 @@ public class PersonAddressResource1_8 extends DelegatingSubResource<PersonAddres
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -190,6 +198,10 @@ public class PersonAddressResource1_8 extends DelegatingSubResource<PersonAddres
 		        .property("longitude", new StringProperty());
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAddressResource1_8.java
@@ -141,7 +141,7 @@ public class PersonAddressResource1_8 extends DelegatingSubResource<PersonAddres
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -174,7 +174,7 @@ public class PersonAddressResource1_8 extends DelegatingSubResource<PersonAddres
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -199,7 +199,7 @@ public class PersonAddressResource1_8 extends DelegatingSubResource<PersonAddres
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
@@ -152,6 +152,10 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -174,6 +178,10 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -189,6 +197,10 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeResource1_8.java
@@ -153,7 +153,7 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -179,7 +179,7 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -198,7 +198,7 @@ public class PersonAttributeResource1_8 extends DelegatingSubResource<PersonAttr
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeTypeResource1_8.java
@@ -120,7 +120,7 @@ public class PersonAttributeTypeResource1_8 extends MetadataDelegatingCrudResour
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -145,7 +145,7 @@ public class PersonAttributeTypeResource1_8 extends MetadataDelegatingCrudResour
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -161,7 +161,7 @@ public class PersonAttributeTypeResource1_8 extends MetadataDelegatingCrudResour
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonAttributeTypeResource1_8.java
@@ -119,6 +119,10 @@ public class PersonAttributeTypeResource1_8 extends MetadataDelegatingCrudResour
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -140,6 +144,10 @@ public class PersonAttributeTypeResource1_8 extends MetadataDelegatingCrudResour
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -152,6 +160,10 @@ public class PersonAttributeTypeResource1_8 extends MetadataDelegatingCrudResour
 		        .required("description");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonNameResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonNameResource1_8.java
@@ -106,7 +106,7 @@ public class PersonNameResource1_8 extends DelegatingSubResource<PersonName, Per
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -134,7 +134,7 @@ public class PersonNameResource1_8 extends DelegatingSubResource<PersonName, Per
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -154,7 +154,7 @@ public class PersonNameResource1_8 extends DelegatingSubResource<PersonName, Per
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonNameResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonNameResource1_8.java
@@ -105,6 +105,10 @@ public class PersonNameResource1_8 extends DelegatingSubResource<PersonName, Per
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -129,6 +133,10 @@ public class PersonNameResource1_8 extends DelegatingSubResource<PersonName, Per
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -145,6 +153,10 @@ public class PersonNameResource1_8 extends DelegatingSubResource<PersonName, Per
 		        .required("givenName").required("familyName");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
@@ -148,6 +148,10 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -180,6 +184,10 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		ModelImpl model = new ModelImpl()
@@ -198,6 +206,10 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PersonResource1_8.java
@@ -149,7 +149,7 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -185,7 +185,7 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -207,7 +207,7 @@ public class PersonResource1_8 extends DataDelegatingCrudResource<Person> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8.java
@@ -100,7 +100,7 @@ public class PrivilegeResource1_8 extends MetadataDelegatingCrudResource<Privile
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/PrivilegeResource1_8.java
@@ -99,6 +99,10 @@ public class PrivilegeResource1_8 extends MetadataDelegatingCrudResource<Privile
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
@@ -140,7 +140,7 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -169,7 +169,7 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -193,7 +193,7 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramEnrollmentResource1_8.java
@@ -139,6 +139,10 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 		return d;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -164,6 +168,10 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -184,6 +192,10 @@ public class ProgramEnrollmentResource1_8 extends DataDelegatingCrudResource<Pat
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramResource1_8.java
@@ -124,7 +124,7 @@ public class ProgramResource1_8 extends MetadataDelegatingCrudResource<Program> 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -146,7 +146,7 @@ public class ProgramResource1_8 extends MetadataDelegatingCrudResource<Program> 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -164,7 +164,7 @@ public class ProgramResource1_8 extends MetadataDelegatingCrudResource<Program> 
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramResource1_8.java
@@ -123,6 +123,10 @@ public class ProgramResource1_8 extends MetadataDelegatingCrudResource<Program> 
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -141,6 +145,10 @@ public class ProgramResource1_8 extends MetadataDelegatingCrudResource<Program> 
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))
@@ -155,6 +163,10 @@ public class ProgramResource1_8 extends MetadataDelegatingCrudResource<Program> 
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowResource1_8.java
@@ -78,7 +78,7 @@ public class ProgramWorkflowResource1_8 extends MetadataDelegatingCrudResource<P
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowResource1_8.java
@@ -77,6 +77,10 @@ public class ProgramWorkflowResource1_8 extends MetadataDelegatingCrudResource<P
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowStateResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowStateResource1_8.java
@@ -123,7 +123,7 @@ public class ProgramWorkflowStateResource1_8 extends DelegatingSubResource<Progr
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -151,7 +151,7 @@ public class ProgramWorkflowStateResource1_8 extends DelegatingSubResource<Progr
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowStateResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ProgramWorkflowStateResource1_8.java
@@ -122,6 +122,10 @@ public class ProgramWorkflowStateResource1_8 extends DelegatingSubResource<Progr
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -146,6 +150,10 @@ public class ProgramWorkflowStateResource1_8 extends DelegatingSubResource<Progr
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationShipTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationShipTypeResource1_8.java
@@ -137,6 +137,10 @@ public class RelationShipTypeResource1_8 extends MetadataDelegatingCrudResource<
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -152,6 +156,10 @@ public class RelationShipTypeResource1_8 extends MetadataDelegatingCrudResource<
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -162,6 +170,10 @@ public class RelationShipTypeResource1_8 extends MetadataDelegatingCrudResource<
 		        .required("aIsToB").required("bIsToA");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationShipTypeResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationShipTypeResource1_8.java
@@ -138,7 +138,7 @@ public class RelationShipTypeResource1_8 extends MetadataDelegatingCrudResource<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -157,7 +157,7 @@ public class RelationShipTypeResource1_8 extends MetadataDelegatingCrudResource<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -171,7 +171,7 @@ public class RelationShipTypeResource1_8 extends MetadataDelegatingCrudResource<
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
@@ -166,6 +166,10 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -189,6 +193,10 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -209,6 +217,10 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RelationshipResource1_8.java
@@ -167,7 +167,7 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -194,7 +194,7 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -218,7 +218,7 @@ public class RelationshipResource1_8 extends DataDelegatingCrudResource<Relation
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8.java
@@ -131,6 +131,10 @@ public class RoleResource1_8 extends MetadataDelegatingCrudResource<Role> {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -148,6 +152,10 @@ public class RoleResource1_8 extends MetadataDelegatingCrudResource<Role> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -155,6 +163,10 @@ public class RoleResource1_8 extends MetadataDelegatingCrudResource<Role> {
 		        .property("inheritedRoles", new ArrayProperty(new RefProperty("#/definitions/RoleCreate")));
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/RoleResource1_8.java
@@ -132,7 +132,7 @@ public class RoleResource1_8 extends MetadataDelegatingCrudResource<Role> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -153,7 +153,7 @@ public class RoleResource1_8 extends MetadataDelegatingCrudResource<Role> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -164,7 +164,7 @@ public class RoleResource1_8 extends MetadataDelegatingCrudResource<Role> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
@@ -45,7 +45,7 @@ public class ServerLogResource1_8 extends BaseDelegatingResource<ServerLogAction
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
@@ -44,6 +44,10 @@ public class ServerLogResource1_8 extends BaseDelegatingResource<ServerLogAction
 		return rest;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		return ((ModelImpl) super.getGETModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
@@ -197,6 +197,10 @@ public class TaskActionResource1_8 extends BaseDelegatingResource<TaskAction> im
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl();

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/TaskActionResource1_8.java
@@ -198,7 +198,7 @@ public class TaskActionResource1_8 extends BaseDelegatingResource<TaskAction> im
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
@@ -142,6 +142,10 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		//FIXME check valid supportedClass
@@ -169,6 +173,10 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/UserResource1_8.java
@@ -143,7 +143,7 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -174,7 +174,7 @@ public class UserResource1_8 extends MetadataDelegatingCrudResource<UserAndPassw
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeCrudResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeCrudResource1_9.java
@@ -108,6 +108,10 @@ public abstract class BaseAttributeCrudResource1_9<T extends Attribute<?, ?>, P,
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -117,6 +121,10 @@ public abstract class BaseAttributeCrudResource1_9<T extends Attribute<?, ?>, P,
 		        .required("attributeType").required("value");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeCrudResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeCrudResource1_9.java
@@ -109,7 +109,7 @@ public abstract class BaseAttributeCrudResource1_9<T extends Attribute<?, ?>, P,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -122,7 +122,7 @@ public abstract class BaseAttributeCrudResource1_9<T extends Attribute<?, ?>, P,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeTypeCrudResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeTypeCrudResource1_9.java
@@ -30,7 +30,7 @@ import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingC
 public abstract class BaseAttributeTypeCrudResource1_9<T extends AttributeType<?>> extends MetadataDelegatingCrudResource<T> {
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -52,7 +52,7 @@ public abstract class BaseAttributeTypeCrudResource1_9<T extends AttributeType<?
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeTypeCrudResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/BaseAttributeTypeCrudResource1_9.java
@@ -29,6 +29,10 @@ import org.openmrs.module.webservices.rest.web.resource.impl.MetadataDelegatingC
  */
 public abstract class BaseAttributeTypeCrudResource1_9<T extends AttributeType<?>> extends MetadataDelegatingCrudResource<T> {
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -47,6 +51,10 @@ public abstract class BaseAttributeTypeCrudResource1_9<T extends AttributeType<?
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapResource1_9.java
@@ -57,7 +57,7 @@ public class ConceptMapResource1_9 extends ConceptMapResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -79,7 +79,7 @@ public class ConceptMapResource1_9 extends ConceptMapResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapResource1_9.java
@@ -56,6 +56,10 @@ public class ConceptMapResource1_9 extends ConceptMapResource1_8 {
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -74,6 +78,10 @@ public class ConceptMapResource1_9 extends ConceptMapResource1_8 {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapTypeResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapTypeResource1_9.java
@@ -88,6 +88,10 @@ public class ConceptMapTypeResource1_9 extends MetadataDelegatingCrudResource<Co
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -98,6 +102,10 @@ public class ConceptMapTypeResource1_9 extends MetadataDelegatingCrudResource<Co
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapTypeResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptMapTypeResource1_9.java
@@ -89,7 +89,7 @@ public class ConceptMapTypeResource1_9 extends MetadataDelegatingCrudResource<Co
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -103,7 +103,7 @@ public class ConceptMapTypeResource1_9 extends MetadataDelegatingCrudResource<Co
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
@@ -87,6 +87,10 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -104,6 +108,10 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -114,6 +122,10 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 		        .required("termA").required("termB").required("conceptMapType");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermMapResource1_9.java
@@ -88,7 +88,7 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -109,7 +109,7 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -123,7 +123,7 @@ public class ConceptReferenceTermMapResource1_9 extends DelegatingCrudResource<C
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermResource1_9.java
@@ -100,7 +100,7 @@ public class ConceptReferenceTermResource1_9 extends MetadataDelegatingCrudResou
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -122,7 +122,7 @@ public class ConceptReferenceTermResource1_9 extends MetadataDelegatingCrudResou
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -136,7 +136,7 @@ public class ConceptReferenceTermResource1_9 extends MetadataDelegatingCrudResou
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptReferenceTermResource1_9.java
@@ -99,6 +99,10 @@ public class ConceptReferenceTermResource1_9 extends MetadataDelegatingCrudResou
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -117,6 +121,10 @@ public class ConceptReferenceTermResource1_9 extends MetadataDelegatingCrudResou
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))
@@ -127,6 +135,10 @@ public class ConceptReferenceTermResource1_9 extends MetadataDelegatingCrudResou
 		        .required("code").required("conceptSource");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl(); //FIXME missing props

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
@@ -73,7 +73,7 @@ public class ConceptSearchResource1_9 extends BaseDelegatingResource<ConceptSear
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptSearchResource1_9.java
@@ -72,6 +72,10 @@ public class ConceptSearchResource1_9 extends BaseDelegatingResource<ConceptSear
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9.java
@@ -85,7 +85,7 @@ public class ConceptStopwordResource1_9 extends DelegatingCrudResource<ConceptSt
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -103,7 +103,7 @@ public class ConceptStopwordResource1_9 extends DelegatingCrudResource<ConceptSt
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ConceptStopwordResource1_9.java
@@ -84,6 +84,10 @@ public class ConceptStopwordResource1_9 extends DelegatingCrudResource<ConceptSt
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
@@ -98,6 +102,10 @@ public class ConceptStopwordResource1_9 extends DelegatingCrudResource<ConceptSt
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
@@ -41,7 +41,7 @@ public class CustomDatatypeHandlerResource1_9 extends DelegatingSubResource<Cust
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeHandlerResource1_9.java
@@ -40,6 +40,10 @@ public class CustomDatatypeHandlerResource1_9 extends DelegatingSubResource<Cust
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
@@ -103,6 +103,10 @@ public class CustomDatatypeResource1_9 extends DelegatingCrudResource<CustomData
 		return null;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/CustomDatatypeResource1_9.java
@@ -104,7 +104,7 @@ public class CustomDatatypeResource1_9 extends DelegatingCrudResource<CustomData
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterProviderResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterProviderResource1_9.java
@@ -91,7 +91,7 @@ public class EncounterProviderResource1_9 extends DelegatingSubResource<Encounte
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -113,7 +113,7 @@ public class EncounterProviderResource1_9 extends DelegatingSubResource<Encounte
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -132,7 +132,7 @@ public class EncounterProviderResource1_9 extends DelegatingSubResource<Encounte
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterProviderResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterProviderResource1_9.java
@@ -90,6 +90,10 @@ public class EncounterProviderResource1_9 extends DelegatingSubResource<Encounte
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -108,6 +112,10 @@ public class EncounterProviderResource1_9 extends DelegatingSubResource<Encounte
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()
@@ -123,6 +131,10 @@ public class EncounterProviderResource1_9 extends DelegatingSubResource<Encounte
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
@@ -49,7 +49,7 @@ public class EncounterRoleResource1_9 extends MetadataDelegatingCrudResource<Enc
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/EncounterRoleResource1_9.java
@@ -48,6 +48,10 @@ public class EncounterRoleResource1_9 extends MetadataDelegatingCrudResource<Enc
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/FormResourceResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/FormResourceResource1_9.java
@@ -142,7 +142,7 @@ public class FormResourceResource1_9 extends DelegatingSubResource<FormResource,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -166,7 +166,7 @@ public class FormResourceResource1_9 extends DelegatingSubResource<FormResource,
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/FormResourceResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/FormResourceResource1_9.java
@@ -141,6 +141,10 @@ public class FormResourceResource1_9 extends DelegatingSubResource<FormResource,
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
@@ -161,6 +165,10 @@ public class FormResourceResource1_9 extends DelegatingSubResource<FormResource,
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9.java
@@ -120,7 +120,7 @@ public class ProviderResource1_9 extends MetadataDelegatingCrudResource<Provider
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -142,7 +142,7 @@ public class ProviderResource1_9 extends MetadataDelegatingCrudResource<Provider
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -151,7 +151,7 @@ public class ProviderResource1_9 extends MetadataDelegatingCrudResource<Provider
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/ProviderResource1_9.java
@@ -119,6 +119,10 @@ public class ProviderResource1_9 extends MetadataDelegatingCrudResource<Provider
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -137,11 +141,19 @@ public class ProviderResource1_9 extends MetadataDelegatingCrudResource<Provider
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
@@ -118,7 +118,7 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -143,7 +143,7 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -161,7 +161,7 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/SystemSettingResource1_9.java
@@ -117,6 +117,10 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
@@ -138,6 +142,10 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -152,6 +160,10 @@ public class SystemSettingResource1_9 extends DelegatingCrudResource<GlobalPrope
 		        .required("property");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		Model model = getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
@@ -172,6 +172,10 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 		return description;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = (ModelImpl) super.getGETModel(rep);
@@ -197,6 +201,10 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 		return modelImpl;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl().property("patient", new StringProperty().example("uuid"))
@@ -217,6 +225,10 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl().property("visitType", new RefProperty("#/definitions/VisittypeCreate"))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_9/VisitResource1_9.java
@@ -173,7 +173,7 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -202,7 +202,7 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -226,7 +226,7 @@ public class VisitResource1_9 extends DataDelegatingCrudResource<Visit> {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
@@ -123,7 +123,7 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AdministrationLinksResource2_0.java
@@ -122,6 +122,10 @@ public class AdministrationLinksResource2_0 extends BaseDelegatingReadableResour
 		return instance.getLinks();
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertRecipientResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertRecipientResource2_0.java
@@ -99,6 +99,10 @@ public class AlertRecipientResource2_0 extends DelegatingSubResource<AlertRecipi
 		return description;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
@@ -120,6 +124,10 @@ public class AlertRecipientResource2_0 extends DelegatingSubResource<AlertRecipi
 		return modelImpl;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl modelImpl = new ModelImpl()
@@ -132,6 +140,10 @@ public class AlertRecipientResource2_0 extends DelegatingSubResource<AlertRecipi
 		return modelImpl;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertRecipientResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertRecipientResource2_0.java
@@ -100,7 +100,7 @@ public class AlertRecipientResource2_0 extends DelegatingSubResource<AlertRecipi
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -125,7 +125,7 @@ public class AlertRecipientResource2_0 extends DelegatingSubResource<AlertRecipi
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -141,7 +141,7 @@ public class AlertRecipientResource2_0 extends DelegatingSubResource<AlertRecipi
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertResource2_0.java
@@ -150,7 +150,7 @@ public class AlertResource2_0 extends DelegatingCrudResource<Alert> {
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -184,7 +184,7 @@ public class AlertResource2_0 extends DelegatingCrudResource<Alert> {
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -197,7 +197,7 @@ public class AlertResource2_0 extends DelegatingCrudResource<Alert> {
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/AlertResource2_0.java
@@ -149,6 +149,10 @@ public class AlertResource2_0 extends DelegatingCrudResource<Alert> {
 		return Collections.singletonList(RECIPIENTS);
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl modelImpl = ((ModelImpl) super.getGETModel(rep))
@@ -179,6 +183,10 @@ public class AlertResource2_0 extends DelegatingCrudResource<Alert> {
 		return modelImpl;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -188,6 +196,10 @@ public class AlertResource2_0 extends DelegatingCrudResource<Alert> {
 				.property(DATE_TO_EXPIRE, new DateProperty());
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptProposalResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptProposalResource2_0.java
@@ -117,6 +117,10 @@ public class ConceptProposalResource2_0 extends DelegatingCrudResource<ConceptPr
 		return null;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -181,6 +185,10 @@ public class ConceptProposalResource2_0 extends DelegatingCrudResource<ConceptPr
 		return description;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -201,6 +209,10 @@ public class ConceptProposalResource2_0 extends DelegatingCrudResource<ConceptPr
 		return description;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getUPDATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptProposalResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptProposalResource2_0.java
@@ -118,7 +118,7 @@ public class ConceptProposalResource2_0 extends DelegatingCrudResource<ConceptPr
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -186,7 +186,7 @@ public class ConceptProposalResource2_0 extends DelegatingCrudResource<ConceptPr
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -210,7 +210,7 @@ public class ConceptProposalResource2_0 extends DelegatingCrudResource<ConceptPr
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
@@ -87,6 +87,10 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 		return description;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -109,6 +113,10 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 		return model;
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		ModelImpl model = new ModelImpl();

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/ConceptStateConversionResource2_0.java
@@ -88,7 +88,7 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -114,7 +114,7 @@ public class ConceptStateConversionResource2_0 extends DelegatingCrudResource<Co
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
@@ -116,7 +116,7 @@ public class DatabaseChangeResource2_0 extends BaseDelegatingReadableResource<Da
 	}
 
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/DatabaseChangeResource2_0.java
@@ -115,6 +115,10 @@ public class DatabaseChangeResource2_0 extends BaseDelegatingReadableResource<Da
 		return instance.getAuthor() + " " + instance.getDescription();
 	}
 
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/NameTemplateResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/NameTemplateResource2_0.java
@@ -47,6 +47,10 @@ public class NameTemplateResource2_0 extends BaseDelegatingReadableResource<Name
 		return LayoutTemplateRepresentation.getRepresentationDescription(rep);
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		return LayoutTemplateRepresentation.getGETModel(NameTemplateTokenEnum.class);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/NameTemplateResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/NameTemplateResource2_0.java
@@ -48,7 +48,7 @@ public class NameTemplateResource2_0 extends BaseDelegatingReadableResource<Name
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/PatientAllergyResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/PatientAllergyResource2_0.java
@@ -96,6 +96,10 @@ public class PatientAllergyResource2_0 extends DelegatingSubResource<Allergy, Pa
 		return getCreatableProperties();
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
@@ -118,6 +122,10 @@ public class PatientAllergyResource2_0 extends DelegatingSubResource<Allergy, Pa
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -132,6 +140,10 @@ public class PatientAllergyResource2_0 extends DelegatingSubResource<Allergy, Pa
 		        .required("allergen");
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/PatientAllergyResource2_0.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_0/PatientAllergyResource2_0.java
@@ -97,7 +97,7 @@ public class PatientAllergyResource2_0 extends DelegatingSubResource<Allergy, Pa
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -123,7 +123,7 @@ public class PatientAllergyResource2_0 extends DelegatingSubResource<Allergy, Pa
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -141,7 +141,7 @@ public class PatientAllergyResource2_0 extends DelegatingSubResource<Allergy, Pa
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortMembershipResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortMembershipResource2_1.java
@@ -98,6 +98,10 @@ public class CohortMembershipResource2_1 extends DelegatingSubResource<CohortMem
 		return d;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -113,6 +117,10 @@ public class CohortMembershipResource2_1 extends DelegatingSubResource<CohortMem
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
@@ -121,6 +129,10 @@ public class CohortMembershipResource2_1 extends DelegatingSubResource<CohortMem
 		        .property("endDate", new DateProperty());
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortMembershipResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortMembershipResource2_1.java
@@ -99,7 +99,7 @@ public class CohortMembershipResource2_1 extends DelegatingSubResource<CohortMem
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -118,7 +118,7 @@ public class CohortMembershipResource2_1 extends DelegatingSubResource<CohortMem
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -130,7 +130,7 @@ public class CohortMembershipResource2_1 extends DelegatingSubResource<CohortMem
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortResource2_1.java
@@ -34,7 +34,7 @@ public class CohortResource2_1 extends CohortResource1_8 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/CohortResource2_1.java
@@ -33,6 +33,10 @@ public class CohortResource2_1 extends CohortResource1_8 {
 		return RestConstants2_1.RESOURCE_VERSION;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ConceptSourceResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ConceptSourceResource2_1.java
@@ -29,6 +29,10 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0.ConceptS
         "2.1.* - 9.*" })
 public class ConceptSourceResource2_1 extends ConceptSourceResource2_0 {
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
@@ -39,6 +43,10 @@ public class ConceptSourceResource2_1 extends ConceptSourceResource2_0 {
 		return model;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation representation) {
 		return ((ModelImpl) super.getCREATEModel(representation))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ConceptSourceResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ConceptSourceResource2_1.java
@@ -30,7 +30,7 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0.ConceptS
 public class ConceptSourceResource2_1 extends ConceptSourceResource2_0 {
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -44,7 +44,7 @@ public class ConceptSourceResource2_1 extends ConceptSourceResource2_0 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1.java
@@ -27,7 +27,7 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11.ObsReso
 public class ObsResource2_1 extends ObsResource1_11 {
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override
@@ -38,7 +38,7 @@ public class ObsResource2_1 extends ObsResource1_11 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/ObsResource2_1.java
@@ -26,6 +26,10 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_11.ObsReso
 @Resource(name = RestConstants.VERSION_1 + "/obs", supportedClass = Obs.class, supportedOpenmrsVersions = { "2.1.* - 2.6.*" })
 public class ObsResource2_1 extends ObsResource1_11 {
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getGETModel(Representation rep) {
 		return ((ModelImpl) super.getGETModel(rep))
@@ -33,6 +37,10 @@ public class ObsResource2_1 extends ObsResource1_11 {
 		        .property("interpretation", new EnumProperty(Obs.Interpretation.class));
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		return ((ModelImpl) super.getCREATEModel(rep))

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/PersonNameResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/PersonNameResource2_1.java
@@ -29,7 +29,7 @@ public class PersonNameResource2_1 extends PersonNameResource2_0 {
 	}
 	
 	/**
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	@Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/PersonNameResource2_1.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_1/PersonNameResource2_1.java
@@ -28,6 +28,10 @@ public class PersonNameResource2_1 extends PersonNameResource2_0 {
 		return resourceDescription;
 	}
 	
+	/**
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 */
+	@Deprecated
 	@Override
 	public Model getCREATEModel(Representation rep) {
 		Model model = super.getCREATEModel(rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/ConditionResource2_2.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/ConditionResource2_2.java
@@ -92,7 +92,9 @@ public class ConditionResource2_2 extends DataDelegatingCrudResource<Condition> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getGETModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = ((ModelImpl) super.getGETModel(rep));
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -114,8 +116,10 @@ public class ConditionResource2_2 extends DataDelegatingCrudResource<Condition> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getCREATEModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
 		        .property("condition", new StringProperty())
@@ -130,8 +134,10 @@ public class ConditionResource2_2 extends DataDelegatingCrudResource<Condition> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getUPDATEModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getUPDATEModel(Representation representation) {
 		return new ModelImpl()
 		        .property("condition", new StringProperty())

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/ConditionResource2_2.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/ConditionResource2_2.java
@@ -92,7 +92,7 @@ public class ConditionResource2_2 extends DataDelegatingCrudResource<Condition> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getGETModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Deprecated
 	public Model getGETModel(Representation rep) {
@@ -116,7 +116,7 @@ public class ConditionResource2_2 extends DataDelegatingCrudResource<Condition> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getCREATEModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated
@@ -134,7 +134,7 @@ public class ConditionResource2_2 extends DataDelegatingCrudResource<Condition> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getUPDATEModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/DiagnosisResource2_2.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/DiagnosisResource2_2.java
@@ -136,7 +136,7 @@ public class DiagnosisResource2_2 extends DataDelegatingCrudResource<Diagnosis> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getGETModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated
@@ -190,7 +190,7 @@ public class DiagnosisResource2_2 extends DataDelegatingCrudResource<Diagnosis> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getCREATEModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated
@@ -225,7 +225,7 @@ public class DiagnosisResource2_2 extends DataDelegatingCrudResource<Diagnosis> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getUPDATEModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/DiagnosisResource2_2.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_2/DiagnosisResource2_2.java
@@ -136,8 +136,10 @@ public class DiagnosisResource2_2 extends DataDelegatingCrudResource<Diagnosis> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getGETModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -188,8 +190,10 @@ public class DiagnosisResource2_2 extends DataDelegatingCrudResource<Diagnosis> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getCREATEModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getCREATEModel(Representation rep) {
 
 		return new ModelImpl()
@@ -221,8 +225,10 @@ public class DiagnosisResource2_2 extends DataDelegatingCrudResource<Diagnosis> 
 	
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getUPDATEModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()
 		        .property("diagnosis", new StringProperty())

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_3/FulfillerDetailsResource2_3.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_3/FulfillerDetailsResource2_3.java
@@ -57,7 +57,7 @@ public class FulfillerDetailsResource2_3 extends DelegatingSubResource<Fulfiller
     }
 
     /**
-     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
      */
     @Deprecated
     @Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_3/FulfillerDetailsResource2_3.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_3/FulfillerDetailsResource2_3.java
@@ -56,6 +56,10 @@ public class FulfillerDetailsResource2_3 extends DelegatingSubResource<Fulfiller
         return delegatingResourceDescription;
     }
 
+    /**
+     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     */
+    @Deprecated
     @Override
     public Model getCREATEModel(Representation rep) {
         return new ModelImpl()

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5.java
@@ -67,16 +67,28 @@ public class DiagnosisResource2_5 extends DiagnosisResource2_2 {
         return description;
     }
 
+    /**
+     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     */
+    @Deprecated
     @Override
     public Model getGETModel(Representation rep) {
         return addNewProperties(super.getGETModel(rep), rep);
     }
 
+    /**
+     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     */
+    @Deprecated
     @Override
     public Model getCREATEModel(Representation rep) {
         return addNewProperties(super.getCREATEModel(rep), rep);
     }
 
+    /**
+     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     */
+    @Deprecated
     @Override
     public Model getUPDATEModel(Representation rep) {
         return addNewProperties(super.getUPDATEModel(rep), rep);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_5/DiagnosisResource2_5.java
@@ -68,7 +68,7 @@ public class DiagnosisResource2_5 extends DiagnosisResource2_2 {
     }
 
     /**
-     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
      */
     @Deprecated
     @Override
@@ -77,7 +77,7 @@ public class DiagnosisResource2_5 extends DiagnosisResource2_2 {
     }
 
     /**
-     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
      */
     @Deprecated
     @Override
@@ -86,7 +86,7 @@ public class DiagnosisResource2_5 extends DiagnosisResource2_2 {
     }
 
     /**
-     * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+     * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
      */
     @Deprecated
     @Override

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_6/MedicationDispenseResource2_6.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_6/MedicationDispenseResource2_6.java
@@ -130,7 +130,7 @@ public class MedicationDispenseResource2_6 extends DataDelegatingCrudResource<Me
 
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getGETModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated
@@ -175,7 +175,7 @@ public class MedicationDispenseResource2_6 extends DataDelegatingCrudResource<Me
 
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getCREATEModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated
@@ -210,7 +210,7 @@ public class MedicationDispenseResource2_6 extends DataDelegatingCrudResource<Me
 
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getUPDATEModel(Representation)
-	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
+	 * @deprecated since 3.6.0, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
 	@Deprecated

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_6/MedicationDispenseResource2_6.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_6/MedicationDispenseResource2_6.java
@@ -130,8 +130,10 @@ public class MedicationDispenseResource2_6 extends DataDelegatingCrudResource<Me
 
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getGETModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getGETModel(Representation rep) {
 		ModelImpl model = (ModelImpl) super.getGETModel(rep);
 		if (rep instanceof DefaultRepresentation || rep instanceof FullRepresentation) {
@@ -173,8 +175,10 @@ public class MedicationDispenseResource2_6 extends DataDelegatingCrudResource<Me
 
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getCREATEModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getCREATEModel(Representation rep) {
 		return new ModelImpl()
 		        .property("patient", new StringProperty().example("uuid"))
@@ -206,8 +210,10 @@ public class MedicationDispenseResource2_6 extends DataDelegatingCrudResource<Me
 
 	/**
 	 * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceHandler#getUPDATEModel(Representation)
+	 * @deprecated since 4.0.0-SNAPSHOT, this will be replaced by OpenAPI-generated documentation
 	 */
 	@Override
+	@Deprecated
 	public Model getUPDATEModel(Representation rep) {
 		return new ModelImpl()
 		        .property("encounter", new StringProperty().example("uuid"))


### PR DESCRIPTION
## Description of what I changed

Marks `getGETModel(rep)`, `getCREATEModel(rep)`, and `getUPDATEModel(rep)` as `@Deprecated` across all Resource classes that implement them, per RESTWS-1043.

These functions currently duplicate (and sometimes contradict) the property-declaring functions (`getRepresentationDescription`, `getCreatableProperties`, `getUpdatableProperties`), which should be the source of truth for Swagger/OpenAPI typings going forward. Since the Swagger JSON has been broken since 3.7 without much attention, it's safe to assume no one depends on the current output.

This is Phase 1: deprecation only, no removal. Two internal callers still reference these methods and will need updates before removal in Phase 2 (tracked separately, blocked on the 4.x branch): `SwaggerSpecificationCreator.java` and `ServerLogActionWrapper2_4.java`.

`@deprecated` version is set to `3.6.0` since this change applies to the 3.x branch.

## Issue I worked on

see https://openmrs.atlassian.net/browse/RESTWS-1043

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [code style](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have added tests to cover my changes. (If you refactored existing code that was well tested you do not have to add tests) — *N/A: this is a Javadoc/annotation-only change (adding `@Deprecated`), no behavioral change to test.*
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch. — *Note: based on 3.x branch, not master, as agreed with maintainer.*