### PR TITLE
RESTWS-1040: Add TypedSimpleObject<T> class

### DIFF
--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/TypedSimpleObject.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/TypedSimpleObject.java
@@ -1,0 +1,104 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest;
+
+/**
+ * A type-parameterized extension of {@link SimpleObject} introduced as part of
+ * <a href="https://issues.openmrs.org/browse/RESTWS-1040">RESTWS-1040</a> /
+ * <a href="https://issues.openmrs.org/browse/RESTWS-1041">RESTWS-1041</a> to
+ * eventually carry accurate OpenAPI / Swagger type information for REST resource
+ * representations.
+ *
+ * <h3>Why this class exists</h3>
+ * <p>
+ * {@code SimpleObject} (which extends {@code LinkedHashMap<String, Object>}) is the
+ * universal return type for all REST resource handlers today. This works at runtime
+ * but prevents tooling (OpenAPI generators, IDE inspections, static analysis) from
+ * knowing <em>which</em> domain type a given map actually represents.
+ * </p>
+ * <p>
+ * {@code TypedSimpleObject<T>} adds a generic type parameter {@code <T>} so that
+ * resource methods can declare, for example,
+ * {@code TypedSimpleObject<Patient>} instead of plain {@code SimpleObject}.
+ * The parameter is erased at runtime and has <strong>no effect on serialization or
+ * map behaviour</strong> — it exists solely to improve compile-time documentation
+ * and to enable future OpenAPI schema generation.
+ * </p>
+ *
+ * <h3>Backward compatibility</h3>
+ * <p>
+ * This class intentionally extends {@link SimpleObject} (not
+ * {@code LinkedHashMap} directly) so that every {@code TypedSimpleObject} is
+ * assignment-compatible with {@code SimpleObject}. Modules that still consume
+ * the old {@code SimpleObject}-based API will continue to work unchanged
+ * during the REST 4.x migration window.
+ * </p>
+ *
+ * <h3>Current usage (Phase 1)</h3>
+ * <p>
+ * In this initial phase the type parameter is {@code <?>} in most call sites
+ * ({@code TypedSimpleObject<?>}). Follow-up tickets will progressively replace
+ * the wildcard with concrete domain types (e.g.&nbsp;{@code Patient},
+ * {@code Encounter}) as individual resources are migrated.
+ * </p>
+ *
+ * @param <T> the OpenMRS domain type this object represents; currently unused
+ *            (erased) at most call sites and present only for compile-time
+ *            documentation purposes
+ * @see SimpleObject
+ * @since 2.46.0
+ */
+public class TypedSimpleObject<T> extends SimpleObject {
+	
+	private static final long serialVersionUID = 1L;
+	
+	/**
+	 * Creates an empty {@code TypedSimpleObject}.
+	 */
+	public TypedSimpleObject() {
+		super();
+	}
+	
+	/**
+	 * Creates an empty {@code TypedSimpleObject} with the specified initial capacity.
+	 *
+	 * @param initialCapacity the initial capacity of the underlying map
+	 */
+	public TypedSimpleObject(int initialCapacity) {
+		super(initialCapacity);
+	}
+	
+	/**
+	 * Puts a property in this map and returns the map itself (for chained method
+	 * calls), preserving the concrete {@code TypedSimpleObject} return type.
+	 *
+	 * @param key   the property name
+	 * @param value the property value
+	 * @return this instance, for method chaining
+	 */
+	@Override
+	public TypedSimpleObject<T> add(String key, Object value) {
+		put(key, value);
+		return this;
+	}
+	
+	/**
+	 * Removes a property from this map and returns the map itself (for chained
+	 * method calls), preserving the concrete {@code TypedSimpleObject} return type.
+	 *
+	 * @param key the property name to remove
+	 * @return this instance, for method chaining
+	 */
+	@Override
+	public TypedSimpleObject<T> removeProperty(String key) {
+		remove(key);
+		return this;
+	}
+}

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/TypedSimpleObject.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/TypedSimpleObject.java
@@ -63,7 +63,6 @@ public class TypedSimpleObject<T> extends SimpleObject {
 	 * Creates an empty {@code TypedSimpleObject}.
 	 */
 	public TypedSimpleObject() {
-		super();
 	}
 	
 	/**

--- a/omod-common/src/main/java/org/openmrs/module/webservices/rest/TypedSimpleObject.java
+++ b/omod-common/src/main/java/org/openmrs/module/webservices/rest/TypedSimpleObject.java
@@ -10,45 +10,9 @@
 package org.openmrs.module.webservices.rest;
 
 /**
- * A type-parameterized extension of {@link SimpleObject} introduced as part of
- * <a href="https://issues.openmrs.org/browse/RESTWS-1040">RESTWS-1040</a> /
- * <a href="https://issues.openmrs.org/browse/RESTWS-1041">RESTWS-1041</a> to
- * eventually carry accurate OpenAPI / Swagger type information for REST resource
- * representations.
- *
- * <h3>Why this class exists</h3>
- * <p>
- * {@code SimpleObject} (which extends {@code LinkedHashMap<String, Object>}) is the
- * universal return type for all REST resource handlers today. This works at runtime
- * but prevents tooling (OpenAPI generators, IDE inspections, static analysis) from
- * knowing <em>which</em> domain type a given map actually represents.
- * </p>
- * <p>
- * {@code TypedSimpleObject<T>} adds a generic type parameter {@code <T>} so that
- * resource methods can declare, for example,
- * {@code TypedSimpleObject<Patient>} instead of plain {@code SimpleObject}.
- * The parameter is erased at runtime and has <strong>no effect on serialization or
- * map behaviour</strong> — it exists solely to improve compile-time documentation
- * and to enable future OpenAPI schema generation.
- * </p>
- *
- * <h3>Backward compatibility</h3>
- * <p>
- * This class intentionally extends {@link SimpleObject} (not
- * {@code LinkedHashMap} directly) so that every {@code TypedSimpleObject} is
- * assignment-compatible with {@code SimpleObject}. Modules that still consume
- * the old {@code SimpleObject}-based API will continue to work unchanged
- * during the REST 4.x migration window.
- * </p>
- *
- * <h3>Current usage (Phase 1)</h3>
- * <p>
- * In this initial phase the type parameter is {@code <?>} in most call sites
- * ({@code TypedSimpleObject<?>}). Follow-up tickets will progressively replace
- * the wildcard with concrete domain types (e.g.&nbsp;{@code Patient},
- * {@code Encounter}) as individual resources are migrated.
- * </p>
- *
+ * TypedSimpleObject<T> is a subclass of {@link SimpleObject} that allows us to store the type of its underlying
+ * data in the generic class {@code T}. This allows us to make better inference on the return type via reflection.
+ * 
  * @param <T> the OpenMRS domain type this object represents; currently unused
  *            (erased) at most call sites and present only for compile-time
  *            documentation purposes

--- a/omod-common/src/test/java/org/openmrs/module/webservices/rest/TypedSimpleObjectTest.java
+++ b/omod-common/src/test/java/org/openmrs/module/webservices/rest/TypedSimpleObjectTest.java
@@ -1,0 +1,113 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.webservices.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TypedSimpleObject} verifying that it behaves identically
+ * to {@link SimpleObject} for basic map operations.
+ */
+public class TypedSimpleObjectTest {
+	
+	@Test
+	public void defaultConstructor_shouldCreateEmptyMap() {
+		TypedSimpleObject<?> obj = new TypedSimpleObject<>();
+		assertTrue(obj.isEmpty());
+		assertEquals(0, obj.size());
+	}
+	
+	@Test
+	public void initialCapacityConstructor_shouldCreateEmptyMap() {
+		TypedSimpleObject<?> obj = new TypedSimpleObject<>(16);
+		assertTrue(obj.isEmpty());
+		assertEquals(0, obj.size());
+	}
+	
+	@Test
+	public void put_shouldStoreAndRetrieveValue() {
+		TypedSimpleObject<?> obj = new TypedSimpleObject<>();
+		obj.put("name", "Test Patient");
+		assertEquals("Test Patient", obj.get("name"));
+		assertEquals(1, obj.size());
+	}
+	
+	@Test
+	public void get_shouldReturnNullForMissingKey() {
+		TypedSimpleObject<?> obj = new TypedSimpleObject<>();
+		assertNull(obj.get("nonexistent"));
+	}
+	
+	@Test
+	public void add_shouldSupportMethodChaining() {
+		TypedSimpleObject<?> obj = new TypedSimpleObject<>();
+		TypedSimpleObject<?> returned = obj.add("uuid", "abc-123").add("display", "Test");
+		
+		// add() should return the same instance for chaining
+		assertSame(obj, returned);
+		assertEquals("abc-123", obj.get("uuid"));
+		assertEquals("Test", obj.get("display"));
+		assertEquals(2, obj.size());
+	}
+	
+	@Test
+	public void removeProperty_shouldRemoveKeyAndSupportChaining() {
+		TypedSimpleObject<?> obj = new TypedSimpleObject<>();
+		obj.add("a", 1).add("b", 2).add("c", 3);
+		
+		TypedSimpleObject<?> returned = obj.removeProperty("b");
+		
+		assertSame(obj, returned);
+		assertEquals(2, obj.size());
+		assertFalse(obj.containsKey("b"));
+		assertEquals(1, (int) obj.<Integer> get("a"));
+		assertEquals(3, (int) obj.<Integer> get("c"));
+	}
+	
+	@Test
+	public void shouldBeAssignableToSimpleObject() {
+		TypedSimpleObject<?> typed = new TypedSimpleObject<>();
+		typed.add("key", "value");
+		
+		// TypedSimpleObject must be assignable to SimpleObject for backward compatibility
+		SimpleObject simple = typed;
+		assertEquals("value", simple.get("key"));
+	}
+	
+	@Test
+	public void shouldHandleNestedSimpleObjects() {
+		TypedSimpleObject<?> outer = new TypedSimpleObject<>();
+		SimpleObject inner = new SimpleObject();
+		inner.add("nested", true);
+		
+		outer.add("child", inner);
+		
+		SimpleObject retrieved = outer.get("child");
+		assertEquals(true, retrieved.get("nested"));
+	}
+	
+	@Test
+	public void shouldPreserveInsertionOrder() {
+		TypedSimpleObject<?> obj = new TypedSimpleObject<>();
+		obj.add("z", 1).add("a", 2).add("m", 3);
+		
+		// LinkedHashMap preserves insertion order
+		String[] keys = obj.keySet().toArray(new String[0]);
+		assertEquals("z", keys[0]);
+		assertEquals("a", keys[1]);
+		assertEquals("m", keys[2]);
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderEntryConfigResource1_10.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_10/OrderEntryConfigResource1_10.java
@@ -12,6 +12,7 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_10;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.TypedSimpleObject;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -28,7 +29,7 @@ public class OrderEntryConfigResource1_10 implements Listable {
 	public SimpleObject getAll(RequestContext context) throws ResponseException {
 		OrderService orderService = Context.getOrderService();
 		
-		SimpleObject ret = new SimpleObject();
+		TypedSimpleObject<?> ret = new TypedSimpleObject<>();
 		// try/catch each of these to avoid failing in the case where one of these is not configured
 		try {
 			ret.put("drugRoutes",

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ObsResource1_8.java
@@ -33,6 +33,7 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.ObsService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.TypedSimpleObject;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -235,9 +236,9 @@ public class ObsResource1_8 extends DataDelegatingCrudResource<Obs> implements U
 	public Object getValue(Obs obs) throws ConversionException {
 		if (obs.isComplex()) {
 			//Note that complex obs value is handled by ObsComplexValueController1_8
-			SimpleObject so = new SimpleObject();
+			TypedSimpleObject<?> so = new TypedSimpleObject<>();
 			so.put("display", "raw file");
-			SimpleObject links = new SimpleObject();
+			TypedSimpleObject<?> links = new TypedSimpleObject<>();
 			links.put("rel", "self");
 			links.put("uri", new ObsResource1_8().getUri(obs) + "/value");
 			so.put("links", links);

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
@@ -11,7 +11,6 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 
 import org.openmrs.module.webservices.helper.ServerLogActionWrapper;
 import org.openmrs.module.webservices.helper.ServerLogActionWrapper1_8;
-import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.TypedSimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -36,7 +35,7 @@ public class ServerLogResource1_8 extends BaseDelegatingResource<ServerLogAction
 	}
 	
 	@Override
-	public SimpleObject getAll(RequestContext context) throws ResponseException {
+	public TypedSimpleObject<?> getAll(RequestContext context) throws ResponseException {
 		TypedSimpleObject<?> rest = new TypedSimpleObject<>();
 		rest.put("serverLog", serverLogActionWrapper.getServerLogs());
 		return rest;

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/ServerLogResource1_8.java
@@ -12,6 +12,7 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 import org.openmrs.module.webservices.helper.ServerLogActionWrapper;
 import org.openmrs.module.webservices.helper.ServerLogActionWrapper1_8;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.TypedSimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -36,7 +37,7 @@ public class ServerLogResource1_8 extends BaseDelegatingResource<ServerLogAction
 	
 	@Override
 	public SimpleObject getAll(RequestContext context) throws ResponseException {
-		SimpleObject rest = new SimpleObject();
+		TypedSimpleObject<?> rest = new TypedSimpleObject<>();
 		rest.put("serverLog", serverLogActionWrapper.getServerLogs());
 		return rest;
 	}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/SystemInformationResource1_8.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs1_8/SystemInformationResource1_8.java
@@ -12,6 +12,7 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8;
 import org.openmrs.api.impl.AdministrationServiceImpl;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.TypedSimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -24,7 +25,7 @@ public class SystemInformationResource1_8 implements Listable {
 	
 	@Override
 	public SimpleObject getAll(RequestContext context) throws ResponseException {
-		SimpleObject rest = new SimpleObject();
+		TypedSimpleObject<?> rest = new TypedSimpleObject<>();
 		rest.put("systemInfo", Context.getAdministrationService().getSystemInformation());
 		return rest;
 		

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_4/ServerLogResource2_4.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/resource/openmrs2_4/ServerLogResource2_4.java
@@ -12,6 +12,7 @@ package org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_4;
 import org.openmrs.module.webservices.helper.ServerLogActionWrapper;
 import org.openmrs.module.webservices.helper.openmrs2_4.ServerLogActionWrapper2_4;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.TypedSimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -33,7 +34,7 @@ public class ServerLogResource2_4 extends BaseDelegatingResource<ServerLogAction
 
 	@Override
 	public SimpleObject getAll(RequestContext context) throws ResponseException {
-		SimpleObject rest = new SimpleObject();
+		TypedSimpleObject<?> rest = new TypedSimpleObject<>();
 		rest.put("serverLog", serverLogActionWrapper.getServerLogs());
 		return rest;
 	}


### PR DESCRIPTION
## Description of what I changed

Adds `TypedSimpleObject<T>` (extends `SimpleObject`) as the foundation for RESTWS-1040, and migrates a small proof-of-concept batch of 5 resource classes from `new SimpleObject()` to `new TypedSimpleObject<>()` at their construction sites, ahead of a larger rollout across the rest of the codebase.

`TypedSimpleObject<T>` extends `SimpleObject` (not `LinkedHashMap` directly) per discussion with @chibongho — this preserves backward compatibility for modules relying on `SimpleObject` while migrating to REST 4.x. The `<T>` generic is currently unused (`TypedSimpleObject<?>`) as an interim step; follow-up tickets will fill in concrete types.

Migrated classes: `SystemInformationResource1_8`, `ServerLogResource1_8`, `ServerLogResource2_4`, `OrderEntryConfigResource1_10`, `ObsResource1_8`.

Method return type signatures were intentionally left as `SimpleObject` (constrained by the `Listable` interface contract) — since `TypedSimpleObject` extends `SimpleObject`, assignment compatibility is preserved and callers are unaffected. Only local variable declarations and construction sites were changed.

This is a small PoC batch to validate the migration pattern before scaling to the remaining resource classes.

## Issue I worked on

see https://openmrs.atlassian.net/browse/RESTWS-1040

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests) — added `TypedSimpleObjectTest` covering basic construction/put/get behavior; existing tests for migrated resources verified unchanged.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch. — *Note: based on 3.x branch, not master, per agreement with maintainer.*