### PR TITLE
RESTWS-1049: Fix broken tests in master branch 

### DIFF
--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
@@ -195,7 +195,8 @@ public class ConversionUtil1_9Test extends BaseModuleWebContextSensitiveTest {
                 "User without 'Get Patients' privilege should NOT see patient data through custom representation");
 
         // Positive control: the same user and the same representation, but now holding patient access.
-        // Without this, the assertion above would also pass if the privilege check never ran at all.
+        // Without this, the assertion above would pass even if the patient were unreachable on this
+        // visit for a reason unrelated to privileges, which would make it vacuous.
         Object allowedResult;
         try {
             Context.addProxyPrivilege("Get Visits");

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
@@ -231,26 +231,10 @@ public class ConversionUtil1_9Test extends BaseModuleWebContextSensitiveTest {
         person.addName(new PersonName("Limited", null, "User"));
         Context.getPersonService().savePerson(person);
 
-        Role role = new Role("Limited Role");
-        role.setDescription("Role with limited privileges for testing");
-        for (String privName : new String[] { "Get Visits" }) {
-            Privilege priv = userService.getPrivilege(privName);
-            if (priv == null) {
-                priv = new Privilege(privName);
-                priv.setDescription(privName);
-                userService.savePrivilege(priv);
-            }
-            role.addPrivilege(priv);
-        }
-        userService.saveRole(role);
-
         User user = new User(person);
         user.setUsername("limited_user");
-        user.addRole(role);
         for (Role r : new ArrayList<>(user.getAllRoles())) {
-            if (!r.getRole().equals("Limited Role")) {
-                user.removeRole(r);
-            }
+            user.removeRole(r);
         }
         userService.createUser(user, "LimitedTest123");
     }

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
@@ -17,8 +17,6 @@ import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Person;
 import org.openmrs.PersonName;
-import org.openmrs.Privilege;
-import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.Visit;
 import org.openmrs.api.ConceptService;
@@ -32,7 +30,6 @@ import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs1_8.Encounte
 import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
@@ -233,9 +233,6 @@ public class ConversionUtil1_9Test extends BaseModuleWebContextSensitiveTest {
 
         User user = new User(person);
         user.setUsername("limited_user");
-        for (Role r : new ArrayList<>(user.getAllRoles())) {
-            user.removeRole(r);
-        }
         userService.createUser(user, "LimitedTest123");
     }
 }

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
@@ -166,10 +166,10 @@ public class ConversionUtil1_9Test extends BaseModuleWebContextSensitiveTest {
         Context.logout();
         Context.authenticate("limited_user", "LimitedTest123");
         assertTrue(Context.isAuthenticated());
-        // "Limited Role" grants nothing here: role privileges resolve by name from the database, and
-        // this role is created inside the test's uncommitted transaction. The visit is fetched and
-        // converted under a proxy privilege below instead. What matters here is the absence of
-        // patient access, which is what this test is about.
+        // The user holds no roles at all: role privileges resolve by name from the database, so a role
+        // created inside the test's uncommitted transaction would grant nothing anyway. The visit is
+        // fetched and converted under a proxy privilege below instead. What matters here is the
+        // absence of patient access, which is what this test is about.
         assertFalse(Context.hasPrivilege("Get Patients"));
         assertFalse(Context.hasPrivilege("Get People"));
 

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/ConversionUtil1_9Test.java
@@ -161,12 +161,15 @@ public class ConversionUtil1_9Test extends BaseModuleWebContextSensitiveTest {
         SimpleObject adminVisit = (SimpleObject) adminResult;
         assertNotNull(adminVisit.get("patient"), "Admin should see patient data");
 
-        // Create and authenticate as a user who only has "Get Visits"
+        // Create and authenticate as a user without "Get Patients"/"Get People"
         createLimitedUser();
         Context.logout();
         Context.authenticate("limited_user", "LimitedTest123");
         assertTrue(Context.isAuthenticated());
-        assertTrue(Context.hasPrivilege("Get Visits"));
+        // "Limited Role" grants nothing here: role privileges resolve by name from the database, and
+        // this role is created inside the test's uncommitted transaction. The visit is fetched and
+        // converted under a proxy privilege below instead. What matters here is the absence of
+        // patient access, which is what this test is about.
         assertFalse(Context.hasPrivilege("Get Patients"));
         assertFalse(Context.hasPrivilege("Get People"));
 
@@ -179,13 +182,38 @@ public class ConversionUtil1_9Test extends BaseModuleWebContextSensitiveTest {
         }
         assertNotNull(visitAsLimited);
 
-        // Patient property should be omitted because the user lacks "Get Patients"
-        Object limitedResult = ConversionUtil.convertToRepresentation(visitAsLimited,
-                new CustomRepresentation("(uuid,patient:(uuid,display,person:(uuid,gender)))"));
+        // "Get Visits" is held so the visit itself converts; "Get Patients"/"Get People" are not, so
+        // the patient property should be omitted.
+        Object limitedResult;
+        try {
+            Context.addProxyPrivilege("Get Visits");
+            limitedResult = ConversionUtil.convertToRepresentation(visitAsLimited,
+                    new CustomRepresentation("(uuid,patient:(uuid,display,person:(uuid,gender)))"));
+        } finally {
+            Context.removeProxyPrivilege("Get Visits");
+        }
         assertInstanceOf(SimpleObject.class, limitedResult);
         SimpleObject limitedVisit = (SimpleObject) limitedResult;
         assertFalse(limitedVisit.containsKey("patient"),
                 "User without 'Get Patients' privilege should NOT see patient data through custom representation");
+
+        // Positive control: the same user and the same representation, but now holding patient access.
+        // Without this, the assertion above would also pass if the privilege check never ran at all.
+        Object allowedResult;
+        try {
+            Context.addProxyPrivilege("Get Visits");
+            Context.addProxyPrivilege("Get Patients");
+            Context.addProxyPrivilege("Get People");
+            allowedResult = ConversionUtil.convertToRepresentation(visitAsLimited,
+                    new CustomRepresentation("(uuid,patient:(uuid,display,person:(uuid,gender)))"));
+        } finally {
+            Context.removeProxyPrivilege("Get People");
+            Context.removeProxyPrivilege("Get Patients");
+            Context.removeProxyPrivilege("Get Visits");
+        }
+        assertInstanceOf(SimpleObject.class, allowedResult);
+        assertNotNull(((SimpleObject) allowedResult).get("patient"),
+                "User with 'Get Patients' privilege SHOULD see patient data, otherwise the assertion above is vacuous");
     }
 
     public void assertCustomRepresentation(Representation representation, String rep) {

--- a/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ChangePasswordController1_8Test.java
+++ b/omod/src/test/java/org/openmrs/module/webservices/rest/web/v1_0/controller/openmrs1_8/ChangePasswordController1_8Test.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
-import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.UserService;
@@ -107,23 +106,22 @@ public class ChangePasswordController1_8Test extends RestControllerTestUtils {
 	@Test
 	public void testUserChangeOtherUsersPassword() throws Exception {
 		Context.checkCoreDataset();
-		User authenticatedUser = setUpUser("daemon");
+		setUpUser("daemon");
 		
-		Role role = new Role("Privileged Role");
-
-		try {
-			Context.addProxyPrivilege(PrivilegeConstants.GET_PRIVILEGES);
-			role.addPrivilege(service.getPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS));
-			role.addPrivilege(service.getPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES));
-		} finally {
-			Context.removeProxyPrivilege(PrivilegeConstants.GET_PRIVILEGES);
-		}
-		authenticatedUser.addRole(role);
-
 		String newPassword = "newTest9453!#$";
 		
-		MockHttpServletResponse response = handle(newPostRequest(PASSWORD_URI + "/" + RestTestConstants1_8.USER_UUID,
-		    "{\"newPassword\":\"" + newPassword + "\"}"));
+		// Role privileges resolve from the database by name, so stubbing them on an in-memory role no
+		// longer grants them; hold the privileges as proxies so the changePassword gate passes.
+		MockHttpServletResponse response;
+		try {
+			Context.addProxyPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS);
+			Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+			response = handle(newPostRequest(PASSWORD_URI + "/" + RestTestConstants1_8.USER_UUID,
+			    "{\"newPassword\":\"" + newPassword + "\"}"));
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+			Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS);
+		}
 		
 		assertEquals(200, response.getStatus());
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>33.7.0-jre</version>
+				<version>33.7.1-jre</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,13 @@
 				<version>${jacksonVersion}</version>
 				<scope>provided</scope>
 			</dependency>
+			<!-- swagger-core pulls in the "android" flavor of Guava, which lacks the java.time
+			     overloads that openmrs-api relies on; pin the "jre" flavor used by openmrs-core -->
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>33.7.0-jre</version>
+			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>legacyui-omod</artifactId>


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'RESTWS-738 Remove concept property setters from ObsResource classes' -->
<!--- 'RESTWS-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

Upstream core changes broke some of the tests in the master branch for the REST module here. See failing tests [here](https://github.com/openmrs/openmrs-module-webservices.rest/actions/runs/32291007969/job/96191710037). See summary by Claude below. Note that I plan to either remove `swagger-core:1.6.2` or upgrade it to a significantly more recent version soon, so the fix to problem 1 will likely change later. 

Also, if `master` branch in `openmrs-core` is stable enough, we should consider adding a Github action there to build against this module.

Summary by Claude:

**Problem 1 (guava).** openmrs-core `c4aca3af4` (#6233) added `OutboxEventRegistry`, a Spring bean
whose constructor calls `CacheBuilder.expireAfterWrite(Duration.ofMinutes(10))` — an overload that
exists only in the **jre** flavor of Guava, which core manages. But `omod-common` was resolving
`guava:27.0.1-android` via `io.swagger:swagger-core:1.6.2`, which wins Maven's nearest-declaration
mediation. Since the bean loads with every Spring context, all 112 context-sensitive tests in the
module failed at once with `NoSuchMethodError`. Latent defect here, not an upstream regression.
**Fix:** pin `guava:33.7.0-jre` in the root pom's `dependencyManagement`; packaging unchanged.

**Problem 2 (fixtures).** openmrs-core `1b5421a9a` (TRUNK-6712, #6383) added `RolePrivilegeCache` and
rewrote `UserContext.hasPrivilege` — role privileges now come from a cache populated by a daemon
thread that reloads the role from the DB and fails closed if absent, where the old path walked the
in-memory role graph. Both fixtures depended on that removed behaviour: one attached a role purely in
memory, the other saved one inside the test's rolled-back transaction. **Fix:** core's own adaptation
pattern from that commit — `Context.addProxyPrivilege(...)` in try/finally. Test-only.


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://openmrs.atlassian.net/browse/RESTWS-1049

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

